### PR TITLE
feat: add format selection for signage conversion

### DIFF
--- a/src/app/(_)/signage/convert/_components/convert.tsx
+++ b/src/app/(_)/signage/convert/_components/convert.tsx
@@ -9,7 +9,7 @@ import { type FC, useEffect, useRef } from "react";
 export const Convert: FC = () => {
   const data = useAtomValue(SignageConvertAtom);
   if (!data) return <></>;
-  const { signage, files: _files } = data;
+  const { signage, files: _files, format } = data;
   const resolution = useAtomValue(TargetResolutionAtom);
   const setResults = useSetAtom(ResultAtom);
   const router = useRouter();
@@ -24,21 +24,16 @@ export const Convert: FC = () => {
     if (initRef.current) return;
     initRef.current = true;
 
-    postCompressSignage(
-      _files,
-      signage,
-      "eia-v1-RGB24-cropped",
-      1,
-      1,
-      resolution,
-    ).then((result) => {
-      setResults({
-        data: result,
-        format: "eia-v1-RGB24-cropped",
-        version: 1,
-      });
-      router.push("/convert/upload");
-    });
-  }, [_files, signage, router, setResults, resolution]);
+    postCompressSignage(_files, signage, format, 1, 1, resolution).then(
+      (result) => {
+        setResults({
+          data: result,
+          format: format,
+          version: 1,
+        });
+        router.push("/convert/upload");
+      },
+    );
+  }, [_files, signage, format, router, setResults, resolution]);
   return <></>;
 };

--- a/src/app/(_)/signage/page.tsx
+++ b/src/app/(_)/signage/page.tsx
@@ -3,10 +3,11 @@ import { SelectedFilesAtom } from "@/atoms/file-drop";
 import { SignageConvertAtom } from "@/atoms/signage-convert";
 import { Button } from "@/components/ui/button";
 import { DndContext } from "@dnd-kit/core";
+import { Radio } from "antd";
 import { useSetAtom } from "jotai";
 import { PlusCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
-import React from "react";
+import React, { useState } from "react";
 import { SignboardTableHeader } from "./_components/SignboardTableHeader";
 import SlideRow from "./_components/SlideRow";
 import TransitionRow from "./_components/TransitionRow";
@@ -19,6 +20,9 @@ function SignboardEditorPage() {
   const setSignageConvert = useSetAtom(SignageConvertAtom);
   const setSelectedFiles = useSetAtom(SelectedFilesAtom);
   const router = useRouter();
+  const [selectedFormat, setSelectedFormat] = useState<
+    "eia-v1-RGB24-cropped" | "eia-v1-RGB24-cropped-base64"
+  >("eia-v1-RGB24-cropped");
 
   const {
     config,
@@ -46,6 +50,7 @@ function SignboardEditorPage() {
     setSignageConvert({
       signage: manifest,
       files: files,
+      format: selectedFormat,
     });
     setSelectedFiles(files);
     router.push("/signage/convert");
@@ -107,6 +112,22 @@ function SignboardEditorPage() {
         </div>
       </div>
       <div className="mt-8">
+        <div className="mb-4">
+          <h3 className="text-lg font-semibold mb-2">
+            フォーマットを選択してください
+          </h3>
+          <Radio.Group
+            value={selectedFormat}
+            onChange={(e) => setSelectedFormat(e.target.value)}
+          >
+            <Radio.Button value="eia-v1-RGB24-cropped">
+              EIA v1 RGB24 (cropped)
+            </Radio.Button>
+            <Radio.Button value="eia-v1-RGB24-cropped-base64">
+              EIA v1 RGB24 (cropped, base64)
+            </Radio.Button>
+          </Radio.Group>
+        </div>
         <Button onClick={handleGenerateData}>設定データを取得</Button>
       </div>
     </div>

--- a/src/atoms/signage-convert.ts
+++ b/src/atoms/signage-convert.ts
@@ -1,11 +1,13 @@
 import type { EIASignageManifest } from "@/_types/eia/v1";
 import type { SelectedFile } from "@/_types/file-picker";
+import type { TTextureConverterFormat } from "@/_types/text-zip/formats";
 import { atom } from "jotai";
 
 export const SignageConvertAtom = atom<
   | {
       signage: EIASignageManifest;
       files: SelectedFile[];
+      format: TTextureConverterFormat;
     }
   | undefined
 >();


### PR DESCRIPTION
- Add format field to SignageConvertAtom type
- Add format selection UI to signage page with Radio buttons
- Support eia-v1-RGB24-cropped and eia-v1-RGB24-cropped-base64 formats
- Update convert component to use selected format dynamically
- Default format is eia-v1-RGB24-cropped