### PR TITLE
google slide上のスキップマークを尊重するように変更

### DIFF
--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -15,12 +15,13 @@ import {
   showFilePicker,
 } from "@/lib/google";
 import { LoadingOutlined } from "@ant-design/icons";
-import { Button, Flex, Spin } from "antd";
+import { Button, Flex, Spin, message } from "antd";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useState } from "react";
 import { TbBrandGoogleDrive } from "react-icons/tb";
 
 export const GooglePicker = () => {
+  const [messageApi, contextHolder] = message.useMessage();
   const [token, setToken] = useAtom(GooglePickerTokenAtom);
   const isApiLoaded = useAtomValue(IsGooglePickerReadyAtom);
   const setFiles = useSetAtom(SelectedFilesAtom);
@@ -63,34 +64,45 @@ export const GooglePicker = () => {
     if (data.action !== "picked" || !data.docs) return;
     const file = data.docs[0];
     setIsLoading(true);
-    if (file.mimeType === "application/pdf") {
-      const fileObj = new File(
-        [await fetchFileBuffer(file.id)],
-        file.name ?? "unknown file",
-        {
-          type: "application/pdf",
-        },
+    try {
+      if (file.mimeType === "application/pdf") {
+        const fileObj = new File(
+          [await fetchFileBuffer(file.id)],
+          file.name ?? "unknown file",
+          {
+            type: "application/pdf",
+          },
+        );
+        const selectedFiles = await file2selectedFiles(fileObj);
+        setFiles((pv) => [...pv, ...selectedFiles]);
+      }
+      if (file.mimeType === "application/vnd.google-apps.presentation") {
+        const files = await slide2canvas(file.id);
+        setFiles((pv) => [...pv, ...files]);
+      }
+      if (file.mimeType?.startsWith("image/")) {
+        const buffer = await fetchFileBuffer(file.id);
+        const fileObject = new File([buffer], file.name ?? "unknown file", {
+          type: file.mimeType,
+        });
+        const canvas = await file2selectedFiles(fileObject);
+        setFiles((pv) => [...pv, ...canvas]);
+      }
+    } catch (e) {
+      console.error(e);
+      void messageApi.error(
+        e instanceof Error
+          ? e.message
+          : "Failed to load file from Google Drive",
       );
-      const selectedFiles = await file2selectedFiles(fileObj);
-      setFiles((pv) => [...pv, ...selectedFiles]);
+    } finally {
+      setIsLoading(false);
     }
-    if (file.mimeType === "application/vnd.google-apps.presentation") {
-      const files = await slide2canvas(file.id);
-      setFiles((pv) => [...pv, ...files]);
-    }
-    if (file.mimeType?.startsWith("image/")) {
-      const buffer = await fetchFileBuffer(file.id);
-      const fileObject = new File([buffer], file.name ?? "unknown file", {
-        type: file.mimeType,
-      });
-      const canvas = await file2selectedFiles(fileObject);
-      setFiles((pv) => [...pv, ...canvas]);
-    }
-    setIsLoading(false);
   };
 
   return (
     <>
+      {contextHolder}
       <Button
         disabled={!isApiLoaded && !validating}
         icon={
@@ -157,9 +169,9 @@ const slide2canvas = async (slideId: string): Promise<SelectedFile[]> => {
       speakerNote: metadata.items[index].speakerNote,
     }))
     .filter(({ isSkipped }) => !isSkipped)
-    .map(({ canvas, index, speakerNote }) => ({
+    .map(({ canvas, index, speakerNote }, outputIndex) => ({
       id: crypto.randomUUID(),
-      fileName: `${metadata.title}-${index + 1}`,
+      fileName: `${metadata.title}-${outputIndex + 1}`,
       canvas,
       note: speakerNote,
       metadata: {

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -145,8 +145,7 @@ const slide2canvas = async (slideId: string): Promise<SelectedFile[]> => {
 
   if (canvases.length !== metadata.items.length) {
     throw new Error(
-      `Canvas count (${canvases.length}) does not match slide metadata count (${metadata.items.length}). ` +
-        "The PDF export may not include all slides.",
+      `Canvas count (${canvases.length}) does not match slide metadata count (${metadata.items.length}). The PDF export may not include all slides.`,
     );
   }
 

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -143,16 +143,24 @@ const slide2canvas = async (slideId: string): Promise<SelectedFile[]> => {
     type: "application/pdf",
   });
 
-  return canvases.map((canvas, index) => ({
-    id: crypto.randomUUID(),
-    fileName: `${metadata.title}-${index + 1}`,
-    canvas,
-    note: metadata.items[index].speakerNote,
-    metadata: {
-      fileType: "pdf",
-      file,
+  return canvases
+    .map((canvas, index) => ({
+      canvas,
       index,
-      scale: 1,
-    },
-  }));
+      isSkipped: metadata.items[index].isSkipped,
+      speakerNote: metadata.items[index].speakerNote,
+    }))
+    .filter(({ isSkipped }) => !isSkipped)
+    .map(({ canvas, index, speakerNote }) => ({
+      id: crypto.randomUUID(),
+      fileName: `${metadata.title}-${index + 1}`,
+      canvas,
+      note: speakerNote,
+      metadata: {
+        fileType: "pdf" as const,
+        file,
+        index,
+        scale: 1,
+      },
+    }));
 };

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -143,6 +143,13 @@ const slide2canvas = async (slideId: string): Promise<SelectedFile[]> => {
     type: "application/pdf",
   });
 
+  if (canvases.length !== metadata.items.length) {
+    throw new Error(
+      `Canvas count (${canvases.length}) does not match slide metadata count (${metadata.items.length}). ` +
+        "The PDF export may not include all slides.",
+    );
+  }
+
   return canvases
     .map((canvas, index) => ({
       canvas,


### PR DESCRIPTION
close #20 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation to ensure exported slides match metadata counts.
  * Corrected handling of skipped slides so conversions preserve ordering and indexing.
  * Fixed assignment of speaker notes so notes attach to the correct exported pages.
  * Improved error reporting and loading behavior during file selection, showing user-friendly messages and ensuring loading indicators stop on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Google Slides import flow to respect slides marked as "skipped" in the presentation, fixing a bug where all slides (including intentionally hidden ones) were previously exported and imported. The change also adds proper error handling (`try/catch/finally`) so the loading spinner is never stuck on failure, and surfaces errors to users via Ant Design's `message` API.

Key changes:
- **Skip-slide filtering**: After mapping canvases to metadata, slides with `isSkipped === true` are filtered out before building the final `SelectedFile[]` list. The original slide index is preserved in `metadata.index` (for correct PDF-page referencing) while `outputIndex` is used for sequential `fileName` generation.
- **Length guard**: A strict equality check between `canvases.length` and `metadata.items.length` is added; a mismatch throws a descriptive error rather than silently producing misaligned canvas/metadata pairs.
- **Error handling**: `onFilePicked` is wrapped in `try/catch/finally`, ensuring `setIsLoading(false)` is always called and any thrown error (including the new length-mismatch error) is shown to the user.
- **Minor**: `fileType: "pdf" as const` is added to correctly satisfy the `SelectedFileMetadataPdf` discriminated-union type.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with two minor style suggestions worth addressing before or after.
- The core logic is correct: the length check guards the invariant that the PDF export includes all slides (including skipped ones), the original index is preserved for PDF-page references, and sequential naming is applied for output filenames. Two minor style concerns exist — silent empty result when all slides are skipped, and independent if-blocks that should use else-if — but neither causes a runtime bug under normal usage.
- No files require special attention beyond the two style comments on GooglePicker.tsx.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx | Adds skip-slide filtering in slide2canvas, a PDF/metadata length-equality guard, proper try/catch/finally error handling, and Ant Design message feedback for errors. Two minor style issues: missing user notification when all slides are filtered out, and independent if-blocks that should be if/else if. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant GooglePicker
    participant DriveAPI as Drive API (PDF export)
    participant SlidesAPI as Slides API (metadata)
    participant slide2canvas

    User->>GooglePicker: Pick Google Slides file
    GooglePicker->>slide2canvas: slide2canvas(slideId)
    par Parallel fetch
        slide2canvas->>DriveAPI: fetchSlideAsPdf(slideId)
        DriveAPI-->>slide2canvas: PDF buffer (all slides incl. skipped)
        slide2canvas->>slide2canvas: pdf2canvases(buffer) → canvases[]
    and
        slide2canvas->>SlidesAPI: fetchSlideMetadata(slideId)
        SlidesAPI-->>slide2canvas: { title, items[{speakerNote, isSkipped}] }
    end
    slide2canvas->>slide2canvas: Guard: canvases.length === items.length?
    alt Mismatch
        slide2canvas-->>GooglePicker: throw Error (caught → messageApi.error)
    else Match
        slide2canvas->>slide2canvas: map → [{ canvas, index, isSkipped, speakerNote }]
        slide2canvas->>slide2canvas: filter out isSkipped === true
        slide2canvas->>slide2canvas: map → SelectedFile[] (outputIndex for fileName, original index for PDF ref)
        slide2canvas-->>GooglePicker: SelectedFile[]
        GooglePicker->>GooglePicker: setFiles([...prev, ...files])
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx`, line 78-80 ([link](https://github.com/o-tr/imageslide-converter/blob/88260e8dc6f268519d858e3e0f2ddf23857f48b8/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx#L78-L80)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Unhandled throw leaves loading spinner stuck**

   `slide2canvas` can now throw (line 147–150) if the canvas count doesn't match the metadata count. When that happens, the `await slide2canvas(file.id)` call rejects and the rest of `onFilePicked` is skipped — including `setIsLoading(false)` on line 89. The loading overlay will remain visible indefinitely, with no way for the user to dismiss it or retry.

   Consider wrapping the presentation branch in a try/catch (or wrapping the entire body of `onFilePicked`) so `setIsLoading(false)` is always called:

   ```
   if (file.mimeType === "application/vnd.google-apps.presentation") {
     try {
       const files = await slide2canvas(file.id);
       setFiles((pv) => [...pv, ...files]);
     } catch (e) {
       console.error(e);
       // surface the error to the user (e.g. an ant-design message/notification)
     }
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
   Line: 78-80

   Comment:
   **Unhandled throw leaves loading spinner stuck**

   `slide2canvas` can now throw (line 147–150) if the canvas count doesn't match the metadata count. When that happens, the `await slide2canvas(file.id)` call rejects and the rest of `onFilePicked` is skipped — including `setIsLoading(false)` on line 89. The loading overlay will remain visible indefinitely, with no way for the user to dismiss it or retry.

   Consider wrapping the presentation branch in a try/catch (or wrapping the entire body of `onFilePicked`) so `setIsLoading(false)` is always called:

   ```
   if (file.mimeType === "application/vnd.google-apps.presentation") {
     try {
       const files = await slide2canvas(file.id);
       setFiles((pv) => [...pv, ...files]);
     } catch (e) {
       console.error(e);
       // surface the error to the user (e.g. an ant-design message/notification)
     }
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
Line: 171

Comment:
**No feedback when all slides are skipped**

If every slide in the presentation has `isSkipped === true`, the `.filter()` returns an empty array, `slide2canvas` returns `[]`, and `setFiles` is called with no new entries — all without any error or warning message to the user. The loading overlay disappears silently, leaving the user unsure whether the operation succeeded or failed.

Consider throwing (or showing a warning via `messageApi`) when the filtered result is empty:

```suggestion
    .filter(({ isSkipped }) => !isSkipped)
```

For example, after the `.filter()` step you could add:

```ts
const nonSkipped = slides.filter(({ isSkipped }) => !isSkipped);
if (nonSkipped.length === 0) {
  throw new Error("All slides in this presentation are marked as skipped. No slides were imported.");
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
Line: 68-90

Comment:
**Independent `if` blocks instead of `else if`**

The three MIME-type conditions are mutually exclusive, but they are written as three separate `if` statements instead of an `if/else if/else if` chain. While this doesn't cause a runtime bug today (no MIME type can match more than one branch), it does execute all three checks on every call and leaves the door open for subtle problems if a new branch is ever added that modifies shared state.

```suggestion
      if (file.mimeType === "application/pdf") {
        const fileObj = new File(
          [await fetchFileBuffer(file.id)],
          file.name ?? "unknown file",
          {
            type: "application/pdf",
          },
        );
        const selectedFiles = await file2selectedFiles(fileObj);
        setFiles((pv) => [...pv, ...selectedFiles]);
      } else if (file.mimeType === "application/vnd.google-apps.presentation") {
        const files = await slide2canvas(file.id);
        setFiles((pv) => [...pv, ...files]);
      } else if (file.mimeType?.startsWith("image/")) {
        const buffer = await fetchFileBuffer(file.id);
        const fileObject = new File([buffer], file.name ?? "unknown file", {
          type: file.mimeType,
        });
        const canvas = await file2selectedFiles(fileObject);
        setFiles((pv) => [...pv, ...canvas]);
      }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["指摘事項に対応"](https://github.com/o-tr/imageslide-converter/commit/65a64daa56d234e8ef45a69cd15bda73318d6064)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->