### PR TITLE
Discordログインをポップアップ化

### DIFF
--- a/src/app/(_)/layout.tsx
+++ b/src/app/(_)/layout.tsx
@@ -1,19 +1,26 @@
 import { HeaderLogo } from "@/app/(_)/_components/HeaderLogo";
 import { AntContent } from "@/components/AntContent";
+import { AppShell } from "@/components/AppShell";
 import { Flex } from "antd";
 import type { ReactNode } from "react";
 
-export default function RootLayout({
+export default function MainLayout({
   children,
 }: Readonly<{
   children: ReactNode;
 }>) {
   return (
-    <AntContent className={"flex flex-col"}>
-      <HeaderLogo />
-      <Flex className={"px-8 flex-1 overflow-y-scroll"} vertical gap={"middle"}>
-        {children}
-      </Flex>
-    </AntContent>
+    <AppShell>
+      <AntContent className={"flex flex-col"}>
+        <HeaderLogo />
+        <Flex
+          className={"px-8 flex-1 overflow-y-scroll"}
+          vertical
+          gap={"middle"}
+        >
+          {children}
+        </Flex>
+      </AntContent>
+    </AppShell>
   );
 }

--- a/src/app/(auth-popup)/auth/popup/callback/page.tsx
+++ b/src/app/(auth-popup)/auth/popup/callback/page.tsx
@@ -5,6 +5,17 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 
+const ERROR_MESSAGES: Record<string, string> = {
+  AccessDenied: "アクセスが拒否されました",
+  OAuthAccountNotLinked: "別の方法でログイン済みのアカウントです",
+  OAuthCallback: "認証コールバックでエラーが発生しました",
+  OAuthSignin: "認証の開始に失敗しました",
+};
+
+function getErrorMessage(error: string): string {
+  return ERROR_MESSAGES[error] ?? "エラーが発生しました";
+}
+
 /**
  * 親ウィンドウにpostMessageを送信し、ポップアップを閉じる。
  * window.openerへのアクセスがクロスオリジン制限で失敗する場合に備えてtry/catchで囲む。
@@ -52,7 +63,7 @@ function CallbackContent() {
     return (
       <div className="flex flex-col items-center gap-4 text-center">
         <p className="text-lg">ログインに失敗しました</p>
-        <p className="text-sm text-gray-500">{error}</p>
+        <p className="text-sm text-gray-500">{getErrorMessage(error)}</p>
         <Link href="/">
           <Button type="primary">トップページへ戻る</Button>
         </Link>

--- a/src/app/(auth-popup)/auth/popup/callback/page.tsx
+++ b/src/app/(auth-popup)/auth/popup/callback/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Button, Spin } from "antd";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+
+/**
+ * 親ウィンドウにpostMessageを送信し、ポップアップを閉じる。
+ * window.openerへのアクセスがクロスオリジン制限で失敗する場合に備えてtry/catchで囲む。
+ */
+function notifyOpenerAndClose(message: Record<string, unknown>): boolean {
+  try {
+    if (window.opener && !window.opener.closed) {
+      window.opener.postMessage(message, window.location.origin);
+      window.close();
+      return true;
+    }
+  } catch {
+    // window.openerへのアクセスがDOMExceptionで失敗した場合はフォールバック
+  }
+  return false;
+}
+
+function CallbackContent() {
+  const searchParams = useSearchParams();
+  const [showFallback, setShowFallback] = useState(false);
+  const error = searchParams.get("error");
+
+  useEffect(() => {
+    const message = error
+      ? { type: "auth-callback-complete", success: false, error }
+      : { type: "auth-callback-complete", success: true };
+
+    const sent = notifyOpenerAndClose(message);
+    if (!sent) {
+      // ポップアップ経由でない場合は即座にフォールバックUIを表示
+      setShowFallback(true);
+      return;
+    }
+
+    // window.close() が効かない場合のフォールバック
+    const timer = setTimeout(() => {
+      setShowFallback(true);
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, [error]);
+
+  if (!showFallback) return null;
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center gap-4 text-center">
+        <p className="text-lg">ログインに失敗しました</p>
+        <p className="text-sm text-gray-500">{error}</p>
+        <Link href="/">
+          <Button type="primary">トップページへ戻る</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-4 text-center">
+      <p className="text-lg">ログインが完了しました</p>
+      <p className="text-sm text-gray-500">このウィンドウを閉じてください</p>
+      <Link href="/">
+        <Button type="primary">トップページへ戻る</Button>
+      </Link>
+    </div>
+  );
+}
+
+export default function PopupCallbackPage() {
+  return (
+    <div className="grid place-items-center flex-1">
+      <Suspense fallback={<Spin size="large" />}>
+        <CallbackContent />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/app/(auth-popup)/auth/popup/page.tsx
+++ b/src/app/(auth-popup)/auth/popup/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { Spin } from "antd";
+import { signIn } from "next-auth/react";
+import { useEffect, useRef } from "react";
+
+export default function PopupSignInPage() {
+  const calledRef = useRef(false);
+
+  useEffect(() => {
+    // StrictMode二重レンダリング対策
+    if (calledRef.current) return;
+    calledRef.current = true;
+    void signIn("discord", { callbackUrl: "/auth/popup/callback" });
+  }, []);
+
+  return (
+    <div className="grid place-items-center flex-1">
+      <Spin size="large" />
+    </div>
+  );
+}

--- a/src/app/(auth-popup)/auth/popup/page.tsx
+++ b/src/app/(auth-popup)/auth/popup/page.tsx
@@ -2,20 +2,25 @@
 
 import { Spin } from "antd";
 import { signIn } from "next-auth/react";
+import { useRouter } from "next/navigation";
 import { useEffect, useRef } from "react";
 
 export default function PopupSignInPage() {
   const calledRef = useRef(false);
+  const router = useRouter();
 
   useEffect(() => {
     // StrictMode二重レンダリング対策
     if (calledRef.current) return;
     calledRef.current = true;
-    void signIn("discord", { callbackUrl: "/auth/popup/callback" });
-  }, []);
+    signIn("discord", { callbackUrl: "/auth/popup/callback" }).catch(() => {
+      // OAuth開始失敗時はコールバックページにエラーを渡してフォールバックUIを表示
+      router.replace("/auth/popup/callback?error=OAuthSignin");
+    });
+  }, [router]);
 
   return (
-    <div className="grid place-items-center flex-1">
+    <div className="grid place-items-center min-h-screen">
       <Spin size="large" />
     </div>
   );

--- a/src/app/(auth-popup)/layout.tsx
+++ b/src/app/(auth-popup)/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+/**
+ * ポップアップ用の最小レイアウト。Header/Footerを表示しない。
+ */
+export default function AuthPopupLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  return (
+    <main className="grid place-items-center min-h-screen">{children}</main>
+  );
+}

--- a/src/app/(redirect)/layout.tsx
+++ b/src/app/(redirect)/layout.tsx
@@ -1,0 +1,10 @@
+import { AppShell } from "@/components/AppShell";
+import type { ReactNode } from "react";
+
+export default function RedirectLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  return <AppShell>{children}</AppShell>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,9 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import { Footer } from "@/components/Footer";
 import { GooglePickerProvider } from "@/components/GooglePickerProvider";
-import { Header } from "@/components/Header";
 import { PdfjsProvider } from "@/components/PdfjsProviderClient";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { AntdRegistry } from "@ant-design/nextjs-registry";
-import { Layout } from "antd";
 import { SessionProvider } from "next-auth/react";
 import type { ReactNode } from "react";
 
@@ -25,13 +22,7 @@ export default function RootLayout({
       <body>
         <AntdRegistry>
           <ThemeProvider>
-            <SessionProvider>
-              <Layout className={"!min-h-screen h-screen"}>
-                <Header />
-                {children}
-                <Footer />
-              </Layout>
-            </SessionProvider>
+            <SessionProvider>{children}</SessionProvider>
           </ThemeProvider>
           <PdfjsProvider />
           <GooglePickerProvider />

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,0 +1,18 @@
+import { Footer } from "@/components/Footer";
+import { Header } from "@/components/Header";
+import { Layout } from "antd";
+import type { ReactNode } from "react";
+
+/**
+ * アプリケーション共通のシェル（Header + Footer + Ant Layout）。
+ * ポップアップなどHeader/Footer不要なルートグループでは使用しない。
+ */
+export function AppShell({ children }: { children: ReactNode }) {
+  return (
+    <Layout className={"!min-h-screen h-screen"}>
+      <Header />
+      {children}
+      <Footer />
+    </Layout>
+  );
+}

--- a/src/components/Header/UserControl/SignIn.tsx
+++ b/src/components/Header/UserControl/SignIn.tsx
@@ -1,25 +1,44 @@
 import { popupSignIn } from "@/lib/auth/popupSignIn";
 import { Button } from "antd";
 import { useSession } from "next-auth/react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export const SignIn = () => {
   const { update } = useSession();
   const [loading, setLoading] = useState(false);
+  const cancelRef = useRef<(() => void) | null>(null);
+
+  // アンマウント時にリスナー/タイマーを解除
+  useEffect(() => {
+    return () => {
+      cancelRef.current?.();
+      cancelRef.current = null;
+    };
+  }, []);
 
   const handleSignIn = useCallback(() => {
+    cancelRef.current?.();
     setLoading(true);
-    popupSignIn({
+    const cancel = popupSignIn({
       onSuccess: async () => {
+        cancelRef.current = null;
         await update();
         setLoading(false);
       },
       onError: (error) => {
+        cancelRef.current = null;
         console.warn("[popupSignIn]", error);
         setLoading(false);
       },
       fallbackToRedirect: true,
     });
+    cancelRef.current = cancel;
+
+    // フォールバックリダイレクトの場合は null が返る。
+    // リダイレクトが遅延・失敗した場合に備えてローディングを解除する。
+    if (cancel === null) {
+      setLoading(false);
+    }
   }, [update]);
 
   return (

--- a/src/components/Header/UserControl/SignIn.tsx
+++ b/src/components/Header/UserControl/SignIn.tsx
@@ -1,9 +1,28 @@
+import { popupSignIn } from "@/lib/auth/popupSignIn";
 import { Button } from "antd";
-import { signIn } from "next-auth/react";
+import { useSession } from "next-auth/react";
+import { useCallback, useState } from "react";
 
 export const SignIn = () => {
+  const { update } = useSession();
+  const [loading, setLoading] = useState(false);
+
+  const handleSignIn = useCallback(() => {
+    setLoading(true);
+    popupSignIn({
+      onSuccess: () => {
+        void update();
+        setLoading(false);
+      },
+      onError: () => {
+        setLoading(false);
+      },
+      fallbackToRedirect: true,
+    });
+  }, [update]);
+
   return (
-    <Button onClick={() => signIn("discord", { callbackUrl: "/" })}>
+    <Button onClick={handleSignIn} loading={loading}>
       Sign in / Sign up
     </Button>
   );

--- a/src/components/Header/UserControl/SignIn.tsx
+++ b/src/components/Header/UserControl/SignIn.tsx
@@ -10,11 +10,12 @@ export const SignIn = () => {
   const handleSignIn = useCallback(() => {
     setLoading(true);
     popupSignIn({
-      onSuccess: () => {
-        void update();
+      onSuccess: async () => {
+        await update();
         setLoading(false);
       },
-      onError: () => {
+      onError: (error) => {
+        console.warn("[popupSignIn]", error);
         setLoading(false);
       },
       fallbackToRedirect: true,

--- a/src/lib/auth/popupSignIn.ts
+++ b/src/lib/auth/popupSignIn.ts
@@ -1,8 +1,8 @@
 import { signIn } from "next-auth/react";
 
 type PopupSignInOptions = {
-  onSuccess?: () => void;
-  onError?: (error: string) => void;
+  onSuccess?: () => void | Promise<void>;
+  onError?: (error: string) => void | Promise<void>;
   /** ポップアップが開けない場合にフルリダイレクトにフォールバックするか (default: true) */
   fallbackToRedirect?: boolean;
   /** フルリダイレクトにフォールバックした場合のcallbackUrl (default: window.location.href) */
@@ -18,7 +18,11 @@ function isMobileDevice(): boolean {
   );
 }
 
-// 前回の呼び出しのクリーンアップ用
+/**
+ * 前回の呼び出しのクリーンアップ用。
+ * モジュールレベルのシングルトン変数であり、同一タブ内のすべてのコンポーネントで共有される。
+ * 複数箇所から同時に呼ばれた場合、後の呼び出しが前の呼び出しのリスナーを破棄する。
+ */
 let cleanupPrevious: (() => void) | null = null;
 
 /**
@@ -40,7 +44,7 @@ export function popupSignIn(options?: PopupSignInOptions): void {
     if (fallback) {
       void signIn("discord", { callbackUrl });
     } else {
-      options?.onError?.("mobile-unsupported");
+      void options?.onError?.("mobile-unsupported");
     }
     return;
   }
@@ -62,7 +66,7 @@ export function popupSignIn(options?: PopupSignInOptions): void {
     if (fallback) {
       void signIn("discord", { callbackUrl });
     } else {
-      options?.onError?.("popup-blocked");
+      void options?.onError?.("popup-blocked");
     }
     return;
   }
@@ -70,7 +74,10 @@ export function popupSignIn(options?: PopupSignInOptions): void {
   // onSuccess/onErrorの二重発火を防ぐフラグ
   let settled = false;
 
-  // ポップアップからのpostMessageを待機
+  // handleMessage, pollTimer, cleanup は相互参照するクロージャ群。
+  // 各関数は非同期でのみ呼ばれるため、宣言順に関わらずランタイムでは初期化済み。
+  // pollTimer を const にするため、cleanup を最後に宣言する。
+
   const handleMessage = (event: MessageEvent) => {
     if (event.origin !== window.location.origin) return;
     if (event.data?.type !== "auth-callback-complete") return;
@@ -80,11 +87,12 @@ export function popupSignIn(options?: PopupSignInOptions): void {
     cleanup();
 
     if (event.data.success) {
-      options?.onSuccess?.();
+      void options?.onSuccess?.();
     } else {
-      options?.onError?.(event.data.error ?? "unknown");
+      void options?.onError?.(event.data.error ?? "unknown");
     }
   };
+
   window.addEventListener("message", handleMessage);
 
   // ポップアップが認証完了前に閉じられた場合の検出
@@ -96,7 +104,7 @@ export function popupSignIn(options?: PopupSignInOptions): void {
       }
       settled = true;
       cleanup();
-      options?.onError?.("popup-closed");
+      void options?.onError?.("popup-closed");
     }
   }, 500);
 

--- a/src/lib/auth/popupSignIn.ts
+++ b/src/lib/auth/popupSignIn.ts
@@ -14,7 +14,7 @@ function isMobileDevice(): boolean {
   return (
     /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
       navigator.userAgent,
-    ) || window.innerWidth < 768
+    ) || screen.width < 768
   );
 }
 
@@ -28,8 +28,10 @@ let cleanupPrevious: (() => void) | null = null;
 /**
  * Discord OAuthをポップアップウィンドウで実行する。
  * モバイルやポップアップブロック時はフルリダイレクトにフォールバック。
+ * @returns クリーンアップ関数。リスナー/タイマーを解除しポップアップフローを中断する。
+ *          フォールバック（リダイレクト/モバイル）の場合は null。
  */
-export function popupSignIn(options?: PopupSignInOptions): void {
+export function popupSignIn(options?: PopupSignInOptions): (() => void) | null {
   // 前回のリスナー/タイマーをクリーンアップ
   cleanupPrevious?.();
   cleanupPrevious = null;
@@ -46,7 +48,7 @@ export function popupSignIn(options?: PopupSignInOptions): void {
     } else {
       void options?.onError?.("mobile-unsupported");
     }
-    return;
+    return null;
   }
 
   // ポップアップをスクリーン中央に配置
@@ -68,7 +70,7 @@ export function popupSignIn(options?: PopupSignInOptions): void {
     } else {
       void options?.onError?.("popup-blocked");
     }
-    return;
+    return null;
   }
 
   // onSuccess/onErrorの二重発火を防ぐフラグ
@@ -115,4 +117,6 @@ export function popupSignIn(options?: PopupSignInOptions): void {
   };
 
   cleanupPrevious = cleanup;
+
+  return cleanup;
 }

--- a/src/lib/auth/popupSignIn.ts
+++ b/src/lib/auth/popupSignIn.ts
@@ -1,0 +1,110 @@
+import { signIn } from "next-auth/react";
+
+type PopupSignInOptions = {
+  onSuccess?: () => void;
+  onError?: (error: string) => void;
+  /** ポップアップが開けない場合にフルリダイレクトにフォールバックするか (default: true) */
+  fallbackToRedirect?: boolean;
+  /** フルリダイレクトにフォールバックした場合のcallbackUrl (default: window.location.href) */
+  callbackUrl?: string;
+};
+
+function isMobileDevice(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+      navigator.userAgent,
+    ) || window.innerWidth < 768
+  );
+}
+
+// 前回の呼び出しのクリーンアップ用
+let cleanupPrevious: (() => void) | null = null;
+
+/**
+ * Discord OAuthをポップアップウィンドウで実行する。
+ * モバイルやポップアップブロック時はフルリダイレクトにフォールバック。
+ */
+export function popupSignIn(options?: PopupSignInOptions): void {
+  // 前回のリスナー/タイマーをクリーンアップ
+  cleanupPrevious?.();
+  cleanupPrevious = null;
+
+  const fallback = options?.fallbackToRedirect !== false;
+  const callbackUrl =
+    options?.callbackUrl ??
+    (typeof window !== "undefined" ? window.location.href : "/");
+
+  // モバイルではポップアップが不安定なためフルリダイレクトにフォールバック
+  if (isMobileDevice()) {
+    if (fallback) {
+      void signIn("discord", { callbackUrl });
+    } else {
+      options?.onError?.("mobile-unsupported");
+    }
+    return;
+  }
+
+  // ポップアップをスクリーン中央に配置
+  const width = 500;
+  const height = 700;
+  const left = window.screenX + (window.outerWidth - width) / 2;
+  const top = window.screenY + (window.outerHeight - height) / 2;
+
+  const popup = window.open(
+    "/auth/popup",
+    "discord-auth-popup",
+    `width=${width},height=${height},left=${left},top=${top},popup=yes`,
+  );
+
+  // ポップアップがブロックされた場合
+  if (!popup || popup.closed) {
+    if (fallback) {
+      void signIn("discord", { callbackUrl });
+    } else {
+      options?.onError?.("popup-blocked");
+    }
+    return;
+  }
+
+  // onSuccess/onErrorの二重発火を防ぐフラグ
+  let settled = false;
+
+  // ポップアップからのpostMessageを待機
+  const handleMessage = (event: MessageEvent) => {
+    if (event.origin !== window.location.origin) return;
+    if (event.data?.type !== "auth-callback-complete") return;
+    if (settled) return;
+    settled = true;
+
+    cleanup();
+
+    if (event.data.success) {
+      options?.onSuccess?.();
+    } else {
+      options?.onError?.(event.data.error ?? "unknown");
+    }
+  };
+  window.addEventListener("message", handleMessage);
+
+  // ポップアップが認証完了前に閉じられた場合の検出
+  const pollTimer = setInterval(() => {
+    if (popup.closed) {
+      if (settled) {
+        cleanup();
+        return;
+      }
+      settled = true;
+      cleanup();
+      options?.onError?.("popup-closed");
+    }
+  }, 500);
+
+  const cleanup = () => {
+    window.removeEventListener("message", handleMessage);
+    clearInterval(pollTimer);
+    cleanupPrevious = null;
+  };
+
+  cleanupPrevious = cleanup;
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,3 +1,3 @@
 export const restrictedRoutes = ["/my/"];
-export const authRoutes = ["/login", "/register"];
+export const authRoutes = ["/login", "/register", "/auth/popup"];
 export const DEFAULT_LOGIN_REDIRECT = "/";

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,3 +1,5 @@
 export const restrictedRoutes = ["/my/"];
+// Note: /auth/popup/callback is intentionally NOT listed here — it must remain
+// accessible to the now-authenticated user after the OAuth redirect completes.
 export const authRoutes = ["/login", "/register", "/auth/popup"];
 export const DEFAULT_LOGIN_REDIRECT = "/";


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord sign-in now opens in a popup window instead of redirecting the full page.
  * Improved error handling with user-friendly messages for failed authentications.
  * Added automatic fallback to redirect-based sign-in for mobile users and blocked popups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the Discord sign-in flow to use a popup window instead of a full-page redirect, with automatic fallback to redirect for mobile devices and popup-blocked scenarios. It also extracts the shared `AppShell` component (Ant Design `Layout` + `Header` + `Footer`) from the root layout into a dedicated component, applying it only to the relevant route groups (`(_)` and `(redirect)`) via their own layouts.

**Key changes:**
- New `src/lib/auth/popupSignIn.ts` utility handles popup lifecycle: opens a named window at `/auth/popup`, listens for a `postMessage` completion signal, polls for premature close, and returns a cleanup handle to callers.
- New `(auth-popup)` route group with minimal layout for `/auth/popup` (triggers OAuth) and `/auth/popup/callback` (sends `postMessage` to opener, with localised error UI fallback).
- `SignIn.tsx` upgraded to use `popupSignIn`, managing the cancel handle via `useRef` and cleaning up on unmount.
- Root `src/app/layout.tsx` stripped of `AppShell`; `AppShell` moved into each route group's layout individually.
- **Regression**: `src/app/page.tsx` (homepage `/`) is at the root level and is **not** inside any route group — it no longer receives the `AppShell` wrapper, meaning the homepage will be rendered without the `Header` (user controls, theme toggle) and `Footer`. All other pages were correctly migrated to route groups, but the root `page.tsx` was missed.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — the homepage at `/` loses its Header and Footer due to a missed migration of `src/app/page.tsx` to a route group.
- The popup sign-in logic itself is well-implemented and most previously flagged issues have been addressed. However, the layout refactor introduced a regression: `src/app/page.tsx` sits at the app root and is not inside any route group that applies `AppShell`. Because `AppShell` was removed from the root layout, the homepage now renders without the fixed user-control header (Sign In button, theme toggle) and footer. This is a functional regression affecting all unauthenticated users landing on `/`.
- `src/app/layout.tsx` and `src/app/page.tsx` — the root page was not moved into a route group after `AppShell` was removed from the root layout.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/auth/popupSignIn.ts | Core popup sign-in utility: opens a named popup window, detects mobile/blocked popups and falls back to redirect, uses `postMessage` + a 500ms poll to detect completion or premature close. The `settled` flag prevents double-firing; cleanup is properly returned to callers and documented as a singleton. Previously flagged issues (screen.width, cleanup ordering comment, module-level JSDoc) have been addressed. |
| src/app/(auth-popup)/auth/popup/callback/page.tsx | Popup callback page: sends a `postMessage` to the opener and closes the window; falls back to a UI with localised error messages if running outside a popup. Minor issue: `flex-1` on the root div is a no-op in the grid parent context. |
| src/components/Header/UserControl/SignIn.tsx | SignIn button now invokes `popupSignIn`, stores the returned cancel handle in a `useRef`, and cleans up on unmount. Loading state is managed correctly; the null-cancel (fallback redirect) case is handled with a comment explaining the intentional early setLoading(false). |
| src/app/layout.tsx | Root layout stripped of AppShell (Header, Footer, Layout). This is correct for popup routes, but leaves `src/app/page.tsx` (homepage `/`) without a Header or Footer — a regression introduced by this PR. |
| src/components/AppShell.tsx | New component extracting the shared Ant Design Layout wrapper with Header and Footer. Clean extraction; correctly documented to be excluded from popup routes. |
| src/routes.ts | Adds `/auth/popup` to `authRoutes` (redirects logged-in users away) while intentionally omitting `/auth/popup/callback` (must remain accessible post-OAuth). The omission is now clearly documented with a comment. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User (SignIn button)
    participant PS as popupSignIn.ts
    participant PW as Popup Window<br/>(/auth/popup)
    participant Discord as Discord OAuth
    participant CB as /auth/popup/callback
    participant S as NextAuth Session

    U->>PS: handleSignIn()
    PS->>PS: isMobileDevice() or popup blocked?
    alt Mobile / Popup blocked
        PS->>S: signIn("discord", {callbackUrl})
        PS-->>U: returns null (fallback redirect)
    else Desktop popup
        PS->>PW: window.open("/auth/popup")
        PS->>PS: addEventListener("message", handleMessage)
        PS->>PS: setInterval(pollTimer, 500ms)
        PS-->>U: returns cleanup()
        PW->>Discord: signIn("discord", {callbackUrl:"/auth/popup/callback"})
        Discord-->>CB: OAuth redirect
        CB->>U: postMessage({type:"auth-callback-complete", success})
        CB->>PW: window.close()
        U->>PS: handleMessage fires
        PS->>PS: cleanup() — removeListener + clearInterval
        PS->>S: onSuccess → session.update()
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/page.tsx`, line 1-39 ([link](https://github.com/o-tr/imageslide-converter/blob/c8df7a8890ad88d5a89f674aab6c4c4f6ba8a5dd/src/app/page.tsx#L1-L39)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Homepage loses Header and Footer**

   The root `src/app/page.tsx` is NOT inside the `(_)` or `(redirect)` route groups. Before this PR, the root `src/app/layout.tsx` rendered `<Layout><Header />{children}<Footer /></Layout>` for all pages. After this PR, the root layout only renders `<SessionProvider>{children}</SessionProvider>`, and `AppShell` (which contains the Header and Footer) is only applied to pages inside the `(_)` and `(redirect)` route groups.

   As a result, the homepage at `/` will be missing its fixed top-right `Header` (user controls and theme toggle) and `Footer`. Users navigating to `/` will see no way to sign in.

   To fix this, move `src/app/page.tsx` into a route group that uses `AppShell`, or wrap its content directly:

   ```
   // Option A: move the file
   src/app/(_)/page.tsx   (or a dedicated route group)

   // Option B: wrap in AppShell directly inside page.tsx
   import { AppShell } from "@/components/AppShell";
   // ... wrap return value in <AppShell>
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/page.tsx
   Line: 1-39

   Comment:
   **Homepage loses Header and Footer**

   The root `src/app/page.tsx` is NOT inside the `(_)` or `(redirect)` route groups. Before this PR, the root `src/app/layout.tsx` rendered `<Layout><Header />{children}<Footer /></Layout>` for all pages. After this PR, the root layout only renders `<SessionProvider>{children}</SessionProvider>`, and `AppShell` (which contains the Header and Footer) is only applied to pages inside the `(_)` and `(redirect)` route groups.

   As a result, the homepage at `/` will be missing its fixed top-right `Header` (user controls and theme toggle) and `Footer`. Users navigating to `/` will see no way to sign in.

   To fix this, move `src/app/page.tsx` into a route group that uses `AppShell`, or wrap its content directly:

   ```
   // Option A: move the file
   src/app/(_)/page.tsx   (or a dedicated route group)

   // Option B: wrap in AppShell directly inside page.tsx
   import { AppShell } from "@/components/AppShell";
   // ... wrap return value in <AppShell>
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/page.tsx
Line: 1-39

Comment:
**Homepage loses Header and Footer**

The root `src/app/page.tsx` is NOT inside the `(_)` or `(redirect)` route groups. Before this PR, the root `src/app/layout.tsx` rendered `<Layout><Header />{children}<Footer /></Layout>` for all pages. After this PR, the root layout only renders `<SessionProvider>{children}</SessionProvider>`, and `AppShell` (which contains the Header and Footer) is only applied to pages inside the `(_)` and `(redirect)` route groups.

As a result, the homepage at `/` will be missing its fixed top-right `Header` (user controls and theme toggle) and `Footer`. Users navigating to `/` will see no way to sign in.

To fix this, move `src/app/page.tsx` into a route group that uses `AppShell`, or wrap its content directly:

```
// Option A: move the file
src/app/(_)/page.tsx   (or a dedicated route group)

// Option B: wrap in AppShell directly inside page.tsx
import { AppShell } from "@/components/AppShell";
// ... wrap return value in <AppShell>
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/(auth-popup)/auth/popup/callback/page.tsx
Line: 87

Comment:
**`flex-1` is a no-op inside a grid container**

The parent `AuthPopupLayout` renders `<main className="grid place-items-center min-h-screen">`, which establishes a **grid** formatting context. The `flex-1` class (`flex-grow: 1`) only has effect inside a **flex** container, so it does nothing here. The vertical centering of the fallback content is already handled by `place-items-center` on the parent.

Consider replacing `flex-1` with `w-full` if you want the div to span the full width, or simply removing it:

```suggestion
      <div className="grid place-items-center">
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["指摘事項に対応"](https://github.com/o-tr/imageslide-converter/commit/c8df7a8890ad88d5a89f674aab6c4c4f6ba8a5dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25963009)</sub>

<!-- /greptile_comment -->