### PR TITLE
トップページのリダイレクト処理を修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,20 +14,31 @@ import { useEffect, useRef } from "react";
 export default function Home() {
   const [files, setFiles] = useAtom(SelectedFilesAtom);
   const setResult = useSetAtom(ResultAtom);
+  const mountedRef = useRef(false);
   const didRedirectRef = useRef(false);
   const router = useRouter();
 
+  // Strict Mode対応: unmount時にrefをリセットし、remountで再度atomクリアが走るようにする
   useEffect(() => {
-    setFiles([]);
-    setResult(undefined);
-  }, [setFiles, setResult]);
+    return () => {
+      mountedRef.current = false;
+      didRedirectRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
+    if (!mountedRef.current) {
+      // マウント時にatomをリセットし、staleな状態によるリダイレクトを防ぐ
+      setFiles([]);
+      setResult(undefined);
+      mountedRef.current = true;
+      return;
+    }
     if (!didRedirectRef.current && files.length > 0) {
       didRedirectRef.current = true;
       router.push("/convert/pick");
     }
-  }, [files.length, router]);
+  }, [files.length, setFiles, setResult, router]);
 
   return (
     <AntContent className={"flex-1 flex flex-col h-full"}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,26 @@
 "use client";
 import { Controls } from "@/app/(_)/convert/pick/_components/FileList/Controls";
 import { TransitionOnDrag } from "@/app/_components/TransitionOnDrag";
+import { ResultAtom } from "@/atoms/convert";
 import { SelectedFilesAtom } from "@/atoms/file-drop";
 import { AntContent } from "@/components/AntContent";
 import { DragWatcher } from "@/components/DragWatcher";
 import { Flex } from "antd";
-import { useAtomValue } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef } from "react";
 
 export default function Home() {
-  const files = useAtomValue(SelectedFilesAtom);
+  const [files, setFiles] = useAtom(SelectedFilesAtom);
+  const setResult = useSetAtom(ResultAtom);
   const didRedirectRef = useRef(false);
   const router = useRouter();
+
+  useEffect(() => {
+    setFiles([]);
+    setResult(undefined);
+  }, [setFiles, setResult]);
 
   useEffect(() => {
     if (!didRedirectRef.current && files.length > 0) {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Home page now resets selected files and conversion results on initial load for a fresh experience.
* **Bug Fixes**
  * Redirect behavior improved to only trigger when files are present and to behave correctly during remounts (fixes issues seen with strict/multiple renders).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where stale atom state (previously selected files or a prior conversion result) could cause the home page to immediately redirect to `/convert/pick` on load. The fix clears `SelectedFilesAtom` and `ResultAtom` on component mount before enabling the redirect listener, with a `mountedRef` guard to correctly handle React Strict Mode's double-invocation.

**Key changes:**
- `useAtomValue` replaced with `useAtom` to obtain the `setFiles` setter, and `useSetAtom` added for `ResultAtom`
- A new `mountedRef` ref distinguishes the first execution of the second `useEffect` (atom-clearing pass) from subsequent executions (redirect-watching pass)
- A cleanup-only first `useEffect` resets both refs on unmount so the atom-clearing logic re-runs if React Strict Mode remounts the component
- Both `setFiles([])` and `setResult(undefined)` are called on mount to guarantee a clean slate regardless of any leftover global atom state from a previous route

**Minor observations:**
- `setFiles([])` always creates a new array reference and will trigger a re-render even when the atom is already empty; guarding with `if (files.length > 0)` would avoid the spurious render
- The first `useEffect` (cleanup-only) is valid but unconventional; consolidating the cleanup into the second effect would improve readability

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; the logic is correct and the Strict Mode handling is sound, with only minor style observations.
- The core redirect-guard logic and Strict Mode double-invocation handling are correct. The `mountedRef` + `didRedirectRef` pattern properly separates the one-time atom-clearing pass from the ongoing file-watching pass. The two minor issues (spurious re-render from `setFiles([])` and the cleanup-only effect pattern) do not affect correctness or runtime behaviour.
- No files require special attention; the single changed file is straightforward.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/page.tsx | Adds state reset on mount (clearing SelectedFilesAtom and ResultAtom) with a mountedRef guard to support React Strict Mode double-invocation and prevent stale state causing premature redirects. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Home page mounts] --> B{mountedRef.current?}
    B -- false --> C[setFiles empty\nsetResult undefined\nmountedRef = true]
    C --> D[Return early — no redirect check]
    B -- true --> E{didRedirectRef.current?}
    E -- true --> F[Already redirected — no-op]
    E -- false --> G{files.length > 0?}
    G -- false --> H[Wait for file drop]
    G -- true --> I[didRedirectRef = true\nrouter.push /convert/pick]
    J[Component unmounts\nStrict Mode cleanup] --> K[mountedRef = false\ndidRedirectRef = false]
    K --> A
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/app/page.tsx`, line 20-30 ([link](https://github.com/o-tr/imageslide-converter/blob/7f2bc0162d9fb2d93c9aeb13cd11bf468b2a47ce/src/app/page.tsx#L20-L30)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Race condition between clearing state and redirect check**

   Both `useEffect` hooks run in the same render cycle after mount. Each closure captures the same `files` value from that render. If the user navigates back to this page while `SelectedFilesAtom` still holds files from a previous session (e.g. after visiting `/convert/pick`), the sequence is:

   1. Effect 1 calls `setFiles([])` — this *queues* a state update but does **not** synchronously update `files`.
   2. Effect 2 evaluates `files.length > 0` using the stale closure value — it sees the old non-empty array, sets `didRedirectRef.current = true`, and calls `router.push("/convert/pick")`.

   The user is therefore immediately bounced back to `/convert/pick` even though the intent of Effect 1 was to clear the state and start fresh. The `didRedirectRef` guard does not help here because it defaults to `false`, allowing the redirect on the very first render.

   A straightforward fix is to initialise `didRedirectRef.current` to `true` (suppressing the stale-state redirect on mount) and reset it to `false` only after the atoms have been cleared, so the redirect can fire again for *newly* dropped files:

   ```tsx
   const didRedirectRef = useRef(true); // suppress redirect on initial mount

   useEffect(() => {
     setFiles([]);
     setResult(undefined);
     didRedirectRef.current = false; // allow redirect once state is clean
   }, [setFiles, setResult]);
   ```

   This way Effect 2 is blocked on the first render (where stale files may be present) and only becomes active after the cleanup effect has run and queued the state reset.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/page.tsx
   Line: 20-30

   Comment:
   **Race condition between clearing state and redirect check**

   Both `useEffect` hooks run in the same render cycle after mount. Each closure captures the same `files` value from that render. If the user navigates back to this page while `SelectedFilesAtom` still holds files from a previous session (e.g. after visiting `/convert/pick`), the sequence is:

   1. Effect 1 calls `setFiles([])` — this *queues* a state update but does **not** synchronously update `files`.
   2. Effect 2 evaluates `files.length > 0` using the stale closure value — it sees the old non-empty array, sets `didRedirectRef.current = true`, and calls `router.push("/convert/pick")`.

   The user is therefore immediately bounced back to `/convert/pick` even though the intent of Effect 1 was to clear the state and start fresh. The `didRedirectRef` guard does not help here because it defaults to `false`, allowing the redirect on the very first render.

   A straightforward fix is to initialise `didRedirectRef.current` to `true` (suppressing the stale-state redirect on mount) and reset it to `false` only after the atoms have been cleared, so the redirect can fire again for *newly* dropped files:

   ```tsx
   const didRedirectRef = useRef(true); // suppress redirect on initial mount

   useEffect(() => {
     setFiles([]);
     setResult(undefined);
     didRedirectRef.current = false; // allow redirect once state is clean
   }, [setFiles, setResult]);
   ```

   This way Effect 2 is blocked on the first render (where stale files may be present) and only becomes active after the cleanup effect has run and queued the state reset.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/app/page.tsx`, line 32 ([link](https://github.com/o-tr/imageslide-converter/blob/2523490314d84326a73e6131165df5042a8c8f2a/src/app/page.tsx#L32)) 

   **Unnecessary re-render when files is already empty**

   `setFiles([])` always creates a new array reference. Since jotai uses `Object.is` for comparison and `[] !== []`, calling `setFiles([])` will always trigger a re-render even if `SelectedFilesAtom` already holds an empty array (its default). This causes one extra render cycle on every home page visit.

   You can guard against this to avoid the spurious re-render:


3. `src/app/page.tsx`, line 22-27 ([link](https://github.com/o-tr/imageslide-converter/blob/2523490314d84326a73e6131165df5042a8c8f2a/src/app/page.tsx#L22-L27)) 

   **Cleanup-only `useEffect` is unconventional**

   Having a `useEffect` whose body is entirely a `return () => { ... }` (i.e., only a cleanup with no setup logic) is valid but unusual and can be surprising to readers. In production (non-Strict-Mode), this cleanup runs when the component unmounts, but a freshly-mounted component instance already has refs initialised to their default values (`false`), so the reset has no observable effect. Its only real purpose is the React Strict Mode double-invocation.

   Consider consolidating the cleanup into the second effect, which already manages the same `mountedRef` and `didRedirectRef`, to make the intent clearer:

   ```ts
   useEffect(() => {
     if (!mountedRef.current) {
       setFiles([]);
       setResult(undefined);
       mountedRef.current = true;
       return;
     }
     if (!didRedirectRef.current && files.length > 0) {
       didRedirectRef.current = true;
       router.push("/convert/pick");
     }
     return () => {
       mountedRef.current = false;
       didRedirectRef.current = false;
     };
   }, [files.length, setFiles, setResult, router]);
   ```

   
   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/page.tsx
Line: 32

Comment:
**Unnecessary re-render when files is already empty**

`setFiles([])` always creates a new array reference. Since jotai uses `Object.is` for comparison and `[] !== []`, calling `setFiles([])` will always trigger a re-render even if `SelectedFilesAtom` already holds an empty array (its default). This causes one extra render cycle on every home page visit.

You can guard against this to avoid the spurious re-render:

```suggestion
      if (files.length > 0) setFiles([]);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/page.tsx
Line: 22-27

Comment:
**Cleanup-only `useEffect` is unconventional**

Having a `useEffect` whose body is entirely a `return () => { ... }` (i.e., only a cleanup with no setup logic) is valid but unusual and can be surprising to readers. In production (non-Strict-Mode), this cleanup runs when the component unmounts, but a freshly-mounted component instance already has refs initialised to their default values (`false`), so the reset has no observable effect. Its only real purpose is the React Strict Mode double-invocation.

Consider consolidating the cleanup into the second effect, which already manages the same `mountedRef` and `didRedirectRef`, to make the intent clearer:

```ts
useEffect(() => {
  if (!mountedRef.current) {
    setFiles([]);
    setResult(undefined);
    mountedRef.current = true;
    return;
  }
  if (!didRedirectRef.current && files.length > 0) {
    didRedirectRef.current = true;
    router.push("/convert/pick");
  }
  return () => {
    mountedRef.current = false;
    didRedirectRef.current = false;
  };
}, [files.length, setFiles, setResult, router]);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["指摘事項に対応"](https://github.com/o-tr/imageslide-converter/commit/2523490314d84326a73e6131165df5042a8c8f2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25974771)</sub>

<!-- /greptile_comment -->