### PR TITLE
Google SlidesのGIFアニメーションをEIA形式で保存・再生する機能を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns-tz": "^3.2.0",
+    "gifuct-js": "^2.1.2",
     "iron-session": "^8.0.4",
     "jotai": "^2.18.1",
     "jszip": "^3.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       date-fns-tz:
         specifier: ^3.2.0
         version: 3.2.0(date-fns@4.1.0)
+      gifuct-js:
+        specifier: ^2.1.2
+        version: 2.1.2
       iron-session:
         specifier: ^8.0.4
         version: 8.0.4
@@ -484,28 +487,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@1.9.4':
     resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@1.9.4':
     resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@1.9.4':
     resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@1.9.4':
     resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
@@ -626,183 +625,155 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -889,35 +860,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.97':
     resolution: {integrity: sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.97':
     resolution: {integrity: sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.97':
     resolution: {integrity: sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.97':
     resolution: {integrity: sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.97':
     resolution: {integrity: sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==}
@@ -955,28 +921,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.0':
     resolution: {integrity: sha512-1ffhC6KY5qWLg5miMlKJp3dZbXelEfjuXt1qcp5WzSCQy36CV3y+JT7OC1WSFKizGQCDOcQbfkH/IjZP3cdRNA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.0':
     resolution: {integrity: sha512-FmbDcZQ8yJRq93EJSL6xaE0KK/Rslraf8fj1uViGxg7K4CKBCRYSubILJPEhjSgZurpcPQq12QNOJQ0DRJl6Hg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.0':
     resolution: {integrity: sha512-HzjIHVkmGAwRbh/vzvoBWWEbb8BBZPxBvVbDQDvzHSf3D8RP/4vjw7MNLDXFF9Q1WEzeQyEj2zdxBtVAHu5Oyw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.0':
     resolution: {integrity: sha512-UMiFNQf5H7+1ZsZPxEsA064WEuFbRNq/kEXyepbCnSErp4f5iut75dBA8UeerFIG3vDaQNOfCpevnERPp2V+nA==}
@@ -1590,28 +1552,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -1872,6 +1830,9 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  gifuct-js@2.1.2:
+    resolution: {integrity: sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1936,6 +1897,9 @@ packages:
         optional: true
       react:
         optional: true
+
+  js-binary-schema-parser@2.0.3:
+    resolution: {integrity: sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2048,28 +2012,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4667,6 +4627,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  gifuct-js@2.1.2:
+    dependencies:
+      js-binary-schema-parser: 2.0.3
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -4709,6 +4673,8 @@ snapshots:
       '@babel/template': 7.28.6
       '@types/react': 18.3.28
       react: 18.3.1
+
+  js-binary-schema-parser@2.0.3: {}
 
   js-tokens@4.0.0: {}
 

--- a/src/_types/eia/rawAnimationData.ts
+++ b/src/_types/eia/rawAnimationData.ts
@@ -1,0 +1,12 @@
+import type { TTextureFormat } from "@/_types/text-zip/formats";
+import type { RawImageObjV1Cropped } from "@/_types/text-zip/v1";
+
+export type RawAnimationData = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  fps: number;
+  format: TTextureFormat;
+  frames: RawImageObjV1Cropped[];
+};

--- a/src/_types/eia/v1.ts
+++ b/src/_types/eia/v1.ts
@@ -1,12 +1,29 @@
 import type { TTextureFormat } from "@/_types/text-zip/formats";
 
-export const EIAExtensions = ["note"];
+export const EIAExtensions = ["note", "a"];
 
 export type EIAExtension = (typeof EIAExtensions)[number];
 
 export type EIAExtensionObject = {
   note?: string;
+  a?: string; // JSON string of EIAAnimationMeta[]
 } & { [key in EIAExtension]?: string };
+
+export type EIAAnimationMeta = {
+  x: number; // pixel X on base image
+  y: number; // pixel Y on base image
+  w: number; // pixel width
+  h: number; // pixel height
+  fps: number; // frame rate
+  f: TTextureFormat; // frame format
+  frames: EIAAnimationFrameRef[];
+};
+
+export type EIAAnimationFrameRef = {
+  s: number; // start offset in data section
+  l: number; // compressed length
+  u: number; // uncompressed size
+};
 
 export type EIACompressionMethod = "lz4" | "lz4-base64";
 
@@ -22,13 +39,13 @@ export type EIAManifestV1 = {
 
 export type EIASignageManifest = {
   [deviceId: string]: EIASignageItem[];
-}
+};
 
 export type EIASignageItem = {
   f: string; // file name
   t: string; // transition
   d: number; // duration
-}
+};
 
 export type EIAFileV1 = EIAFileV1Master | EIAFileV1Cropped;
 

--- a/src/_types/eia/v1.ts
+++ b/src/_types/eia/v1.ts
@@ -19,10 +19,24 @@ export type EIAAnimationMeta = {
   frames: EIAAnimationFrameRef[];
 };
 
-export type EIAAnimationFrameRef = {
+export type EIAAnimationFrameRef =
+  | EIAAnimationFrameRefMaster
+  | EIAAnimationFrameRefCropped;
+
+export type EIAAnimationFrameRefMaster = {
+  t: "m"; // master (full frame)
   s: number; // start offset in data section
   l: number; // compressed length
   u: number; // uncompressed size
+};
+
+export type EIAAnimationFrameRefCropped = {
+  t: "c"; // cropped (diff frame)
+  b: number; // base frame index within this animation's frames array
+  s: number; // start offset in data section
+  l: number; // compressed length
+  u: number; // uncompressed size
+  r: EIAFileV1CroppedPart[]; // changed rects
 };
 
 export type EIACompressionMethod = "lz4" | "lz4-base64";

--- a/src/_types/eia/v1.ts
+++ b/src/_types/eia/v1.ts
@@ -1,6 +1,6 @@
 import type { TTextureFormat } from "@/_types/text-zip/formats";
 
-export const EIAExtensions = ["note", "a"];
+export const EIAExtensions = ["note", "a"] as const;
 
 export type EIAExtension = (typeof EIAExtensions)[number];
 

--- a/src/_types/eia/v1.ts
+++ b/src/_types/eia/v1.ts
@@ -12,8 +12,10 @@ export type EIAExtensionObject = {
 export type EIAAnimationMeta = {
   x: number; // pixel X on base image
   y: number; // pixel Y on base image
-  w: number; // pixel width
-  h: number; // pixel height
+  w: number; // display pixel width
+  h: number; // display pixel height
+  fw?: number; // stored frame pixel width (defaults to w)
+  fh?: number; // stored frame pixel height (defaults to h)
   fps: number; // frame rate
   f: TTextureFormat; // frame format
   frames: EIAAnimationFrameRef[];
@@ -44,7 +46,7 @@ export type EIACompressionMethod = "lz4" | "lz4-base64";
 export type EIAManifestV1 = {
   t: "eia"; //type
   c: EIACompressionMethod; //compressor
-  v: 1; //version
+  v: 1 | 2; //version
   f: string[]; //features
   e: EIAExtension[]; //extensions
   i: EIAFileV1[]; //items

--- a/src/_types/file-picker.ts
+++ b/src/_types/file-picker.ts
@@ -1,9 +1,19 @@
+export type SelectedFileAnimation = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  fps: number;
+  frames: OffscreenCanvas[];
+};
+
 export type SelectedFile = {
   id: string;
   fileName: string;
   note?: string;
   canvas: OffscreenCanvas;
   metadata: SelectedFileMetadata;
+  animations?: SelectedFileAnimation[];
 };
 
 export type SelectedFileMetadataImage = {

--- a/src/_types/google-slides-api.ts
+++ b/src/_types/google-slides-api.ts
@@ -7,6 +7,8 @@ export type SlidePageElement = {
   transform?: {
     scaleX?: number;
     scaleY?: number;
+    shearX?: number;
+    shearY?: number;
     translateX?: number;
     translateY?: number;
     unit?: string;

--- a/src/_types/google-slides-api.ts
+++ b/src/_types/google-slides-api.ts
@@ -1,8 +1,37 @@
+export type SlidePageElement = {
+  objectId?: string;
+  size?: {
+    width: { magnitude: number; unit: string };
+    height: { magnitude: number; unit: string };
+  };
+  transform?: {
+    scaleX?: number;
+    scaleY?: number;
+    translateX?: number;
+    translateY?: number;
+    unit?: string;
+  };
+  image?: {
+    contentUrl?: string;
+    sourceUrl?: string;
+  };
+  shape?: {
+    shapeType: string;
+    text?: {
+      textElements: {
+        textRun?: {
+          content: string;
+        };
+      }[];
+    };
+  };
+};
+
 export type GetSlideResponse = {
   result: {
     slides: {
       objectId: string;
-      pageElements: unknown;
+      pageElements: SlidePageElement[];
       pageProperties: unknown;
       slideProperties: {
         isSkipped?: boolean;
@@ -22,6 +51,10 @@ export type GetSlideResponse = {
         };
       };
     }[];
+    pageSize: {
+      width: { magnitude: number; unit: string };
+      height: { magnitude: number; unit: string };
+    };
     title: string;
   };
 };

--- a/src/_types/lib/google/gifAnimation.ts
+++ b/src/_types/lib/google/gifAnimation.ts
@@ -1,0 +1,11 @@
+import type { SlidePageElement } from "@/_types/google-slides-api";
+import type { PixelRect } from "@/_types/lib/google/slideGeometry";
+import type { ParsedFrame } from "gifuct-js";
+
+export type AnimatedGifCandidate = {
+  element: SlidePageElement;
+  pixelRect: PixelRect;
+  rawFrames: ParsedFrame[];
+  gifWidth: number;
+  gifHeight: number;
+};

--- a/src/_types/lib/google/slideGeometry.ts
+++ b/src/_types/lib/google/slideGeometry.ts
@@ -1,0 +1,16 @@
+export type PageSize = {
+  width: number;
+  height: number;
+};
+
+export type CanvasSize = {
+  width: number;
+  height: number;
+};
+
+export type PixelRect = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+};

--- a/src/_types/slide-preview.ts
+++ b/src/_types/slide-preview.ts
@@ -1,12 +1,23 @@
+export type SlideAnimation = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  fps: number;
+  frames: ImageData[];
+};
+
 export type SlideFrame = {
   index: number;
   width: number;
   height: number;
   imageData: ImageData;
+  animations?: SlideAnimation[];
 };
 
 export type SlideFrameMeta = {
   index: number;
   width: number;
   height: number;
+  hasAnimations?: boolean;
 };

--- a/src/_types/worker.ts
+++ b/src/_types/worker.ts
@@ -3,11 +3,25 @@ import type { TTextureConverterFormat } from "@/_types/text-zip/formats";
 import type { Resolution } from "@/const/resolutions";
 import type { EIASignageManifest } from "./eia/v1";
 
+export type WorkerAnimationBitmap = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  fps: number;
+  frames: ImageBitmap[];
+};
+
+type WorkerFile = Omit<SelectedFile, "canvas" | "animations"> & {
+  bitmap: ImageBitmap;
+  animations?: WorkerAnimationBitmap[];
+};
+
 export type WorkerMessage =
   | {
       type: "compress";
       data: {
-        files: (Omit<SelectedFile, "canvas"> & { bitmap: ImageBitmap })[];
+        files: WorkerFile[];
         format: TTextureConverterFormat;
         version: number;
         scale: number;
@@ -17,7 +31,7 @@ export type WorkerMessage =
   | {
       type: "compress-signage";
       data: {
-        files: (Omit<SelectedFile, "canvas"> & { bitmap: ImageBitmap })[];
+        files: WorkerFile[];
         format: TTextureConverterFormat;
         version: number;
         scale: number;

--- a/src/_types/worker.ts
+++ b/src/_types/worker.ts
@@ -46,6 +46,14 @@ export type WorkerResponse =
       data: string[] | Buffer[];
     }
   | {
+      type: "compress-error";
+      error: string;
+    }
+  | {
       type: "compress-signage";
       data: string[] | Buffer[];
+    }
+  | {
+      type: "compress-signage-error";
+      error: string;
     };

--- a/src/app/(_)/convert/convert/_components/convert.tsx
+++ b/src/app/(_)/convert/convert/_components/convert.tsx
@@ -71,7 +71,9 @@ export const Convert: FC = () => {
         setResults(undefined);
         initRef.current = false;
         console.error("Compression failed:", e);
-        void message.error("変換に失敗しました");
+        void message.error(
+          (e instanceof Error && e.message) || "変換に失敗しました",
+        );
       });
   }, [
     version,

--- a/src/app/(_)/convert/convert/_components/convert.tsx
+++ b/src/app/(_)/convert/convert/_components/convert.tsx
@@ -68,6 +68,8 @@ export const Convert: FC = () => {
         router.push("./upload");
       })
       .catch((e) => {
+        setResults(undefined);
+        initRef.current = false;
         console.error("Compression failed:", e);
         void message.error("変換に失敗しました");
       });

--- a/src/app/(_)/convert/convert/_components/convert.tsx
+++ b/src/app/(_)/convert/convert/_components/convert.tsx
@@ -71,9 +71,7 @@ export const Convert: FC = () => {
         setResults(undefined);
         initRef.current = false;
         console.error("Compression failed:", e);
-        void message.error(
-          (e instanceof Error && e.message) || "変換に失敗しました",
-        );
+        void message.error("変換に失敗しました");
       });
   }, [
     version,

--- a/src/app/(_)/convert/convert/_components/convert.tsx
+++ b/src/app/(_)/convert/convert/_components/convert.tsx
@@ -9,6 +9,7 @@ import { SelectedFilesAtom } from "@/atoms/file-drop";
 import { FileSizeLimit, TargetVersions } from "@/const/convert";
 import { postCompress } from "@/lib/workerService/postCompress";
 import { getAvailableFormats } from "@/utils/getAvailableFormats";
+import { message } from "antd";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useRouter } from "next/navigation";
 import { type FC, useEffect, useMemo, useRef } from "react";
@@ -57,14 +58,19 @@ export const Convert: FC = () => {
       if (!format) return { id: bestFormat.id, scale: 1 };
       return { id: format.id, scale: 1 };
     })();
-    postCompress(_files, id, version, scale, _resolution).then((result) => {
-      setResults({
-        data: result,
-        format: id,
-        version,
+    postCompress(_files, id, version, scale, _resolution)
+      .then((result) => {
+        setResults({
+          data: result,
+          format: id,
+          version,
+        });
+        router.push("./upload");
+      })
+      .catch((e) => {
+        console.error("Compression failed:", e);
+        void message.error("変換に失敗しました");
       });
-      router.push("./upload");
-    });
   }, [
     version,
     _format,

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -165,7 +165,6 @@ const slide2canvas = async (
     );
   }
 
-  const results: SelectedFile[] = [];
   const filteredSlides = canvases
     .map((canvas, index) => ({
       canvas,
@@ -176,37 +175,30 @@ const slide2canvas = async (
     }))
     .filter(({ isSkipped }) => !isSkipped);
 
-  for (
-    let outputIndex = 0;
-    outputIndex < filteredSlides.length;
-    outputIndex++
-  ) {
-    const { canvas, index, speakerNote, pageElements } =
-      filteredSlides[outputIndex];
-
-    // Extract GIF animations from this slide
-    const animations = await extractGifAnimations(
-      pageElements,
-      metadata.pageSize,
-      { width: canvas.width, height: canvas.height },
-      canvas,
-      token,
-    );
-
-    results.push({
-      id: crypto.randomUUID(),
-      fileName: `${metadata.title}-${outputIndex + 1}`,
-      canvas,
-      note: speakerNote,
-      animations: animations.length > 0 ? animations : undefined,
-      metadata: {
-        fileType: "pdf" as const,
-        file,
-        index,
-        scale: 1,
+  return Promise.all(
+    filteredSlides.map(
+      async ({ canvas, index, speakerNote, pageElements }, outputIndex) => {
+        const animations = await extractGifAnimations(
+          pageElements,
+          metadata.pageSize,
+          { width: canvas.width, height: canvas.height },
+          canvas,
+          token,
+        );
+        return {
+          id: crypto.randomUUID(),
+          fileName: `${metadata.title}-${outputIndex + 1}`,
+          canvas,
+          note: speakerNote,
+          animations: animations.length > 0 ? animations : undefined,
+          metadata: {
+            fileType: "pdf" as const,
+            file,
+            index,
+            scale: 1,
+          },
+        };
       },
-    });
-  }
-
-  return results;
+    ),
+  );
 };

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -78,6 +78,11 @@ export const GooglePicker = () => {
         setFiles((pv) => [...pv, ...selectedFiles]);
       }
       if (file.mimeType === "application/vnd.google-apps.presentation") {
+        if (!token) {
+          void messageApi.warning(
+            "認証トークンが無効なため、GIFアニメーションを抽出できません",
+          );
+        }
         const files = await slide2canvas(file.id, token ?? "");
         setFiles((pv) => [...pv, ...files]);
       }

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -178,29 +178,30 @@ const slide2canvas = async (
     }))
     .filter(({ isSkipped }) => !isSkipped);
 
-  const results: SelectedFile[] = [];
-  for (const [outputIndex, slide] of filteredSlides.entries()) {
-    const { canvas, index, speakerNote, pageElements } = slide;
-    const animations = await extractGifAnimations(
-      pageElements,
-      metadata.pageSize,
-      { width: canvas.width, height: canvas.height },
-      canvas,
-      token,
-    );
-    results.push({
-      id: crypto.randomUUID(),
-      fileName: `${metadata.title}-${outputIndex + 1}`,
-      canvas,
-      note: speakerNote,
-      animations: animations.length > 0 ? animations : undefined,
-      metadata: {
-        fileType: "pdf" as const,
-        file,
-        index,
-        scale: 1,
-      },
-    });
-  }
+  const results: SelectedFile[] = await Promise.all(
+    filteredSlides.map(async (slide, outputIndex) => {
+      const { canvas, index, speakerNote, pageElements } = slide;
+      const animations = await extractGifAnimations(
+        pageElements,
+        metadata.pageSize,
+        { width: canvas.width, height: canvas.height },
+        canvas,
+        token,
+      );
+      return {
+        id: crypto.randomUUID(),
+        fileName: `${metadata.title}-${outputIndex + 1}`,
+        canvas,
+        note: speakerNote,
+        animations: animations.length > 0 ? animations : undefined,
+        metadata: {
+          fileType: "pdf" as const,
+          file,
+          index,
+          scale: 1,
+        },
+      };
+    }),
+  );
   return results;
 };

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -14,6 +14,7 @@ import {
   requestTokenPromise,
   showFilePicker,
 } from "@/lib/google";
+import { extractGifAnimations } from "@/lib/google/extractGifAnimations";
 import { LoadingOutlined } from "@ant-design/icons";
 import { Button, Flex, Spin, message } from "antd";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
@@ -77,7 +78,7 @@ export const GooglePicker = () => {
         setFiles((pv) => [...pv, ...selectedFiles]);
       }
       if (file.mimeType === "application/vnd.google-apps.presentation") {
-        const files = await slide2canvas(file.id);
+        const files = await slide2canvas(file.id, token ?? "");
         setFiles((pv) => [...pv, ...files]);
       }
       if (file.mimeType?.startsWith("image/")) {
@@ -139,7 +140,10 @@ export const GooglePicker = () => {
   );
 };
 
-const slide2canvas = async (slideId: string): Promise<SelectedFile[]> => {
+const slide2canvas = async (
+  slideId: string,
+  token: string,
+): Promise<SelectedFile[]> => {
   const [{ canvases, buffer }, metadata] = await Promise.all([
     (async () => {
       const buffer = await fetchSlideAsPdf(slideId);
@@ -161,24 +165,48 @@ const slide2canvas = async (slideId: string): Promise<SelectedFile[]> => {
     );
   }
 
-  return canvases
+  const results: SelectedFile[] = [];
+  const filteredSlides = canvases
     .map((canvas, index) => ({
       canvas,
       index,
       isSkipped: metadata.items[index].isSkipped,
       speakerNote: metadata.items[index].speakerNote,
+      pageElements: metadata.items[index].pageElements,
     }))
-    .filter(({ isSkipped }) => !isSkipped)
-    .map(({ canvas, index, speakerNote }, outputIndex) => ({
+    .filter(({ isSkipped }) => !isSkipped);
+
+  for (
+    let outputIndex = 0;
+    outputIndex < filteredSlides.length;
+    outputIndex++
+  ) {
+    const { canvas, index, speakerNote, pageElements } =
+      filteredSlides[outputIndex];
+
+    // Extract GIF animations from this slide
+    const animations = await extractGifAnimations(
+      pageElements,
+      metadata.pageSize,
+      { width: canvas.width, height: canvas.height },
+      canvas,
+      token,
+    );
+
+    results.push({
       id: crypto.randomUUID(),
       fileName: `${metadata.title}-${outputIndex + 1}`,
       canvas,
       note: speakerNote,
+      animations: animations.length > 0 ? animations : undefined,
       metadata: {
         fileType: "pdf" as const,
         file,
         index,
         scale: 1,
       },
-    }));
+    });
+  }
+
+  return results;
 };

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -183,30 +183,29 @@ const slide2canvas = async (
     }))
     .filter(({ isSkipped }) => !isSkipped);
 
-  return Promise.all(
-    filteredSlides.map(
-      async ({ canvas, index, speakerNote, pageElements }, outputIndex) => {
-        const animations = await extractGifAnimations(
-          pageElements,
-          metadata.pageSize,
-          { width: canvas.width, height: canvas.height },
-          canvas,
-          token,
-        );
-        return {
-          id: crypto.randomUUID(),
-          fileName: `${metadata.title}-${outputIndex + 1}`,
-          canvas,
-          note: speakerNote,
-          animations: animations.length > 0 ? animations : undefined,
-          metadata: {
-            fileType: "pdf" as const,
-            file,
-            index,
-            scale: 1,
-          },
-        };
+  const results: SelectedFile[] = [];
+  for (const [outputIndex, slide] of filteredSlides.entries()) {
+    const { canvas, index, speakerNote, pageElements } = slide;
+    const animations = await extractGifAnimations(
+      pageElements,
+      metadata.pageSize,
+      { width: canvas.width, height: canvas.height },
+      canvas,
+      token,
+    );
+    results.push({
+      id: crypto.randomUUID(),
+      fileName: `${metadata.title}-${outputIndex + 1}`,
+      canvas,
+      note: speakerNote,
+      animations: animations.length > 0 ? animations : undefined,
+      metadata: {
+        fileType: "pdf" as const,
+        file,
+        index,
+        scale: 1,
       },
-    ),
-  );
+    });
+  }
+  return results;
 };

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -58,10 +58,13 @@ export const GooglePicker = () => {
       await showPicker(null);
       return;
     }
-    void showFilePicker(_token, onFilePicked);
+    void showFilePicker(_token, (data) => onFilePicked(data, _token));
   };
 
-  const onFilePicked = async (data: GoogleFilePickerCallbackData) => {
+  const onFilePicked = async (
+    data: GoogleFilePickerCallbackData,
+    currentToken: string,
+  ) => {
     if (data.action !== "picked" || !data.docs) return;
     const file = data.docs[0];
     setIsLoading(true);
@@ -78,12 +81,12 @@ export const GooglePicker = () => {
         setFiles((pv) => [...pv, ...selectedFiles]);
       }
       if (file.mimeType === "application/vnd.google-apps.presentation") {
-        if (!token) {
+        if (!currentToken) {
           void messageApi.warning(
             "認証トークンが無効なため、GIFアニメーションを抽出できません",
           );
         }
-        const files = await slide2canvas(file.id, token ?? "");
+        const files = await slide2canvas(file.id, currentToken);
         setFiles((pv) => [...pv, ...files]);
       }
       if (file.mimeType?.startsWith("image/")) {

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -81,11 +81,6 @@ export const GooglePicker = () => {
         setFiles((pv) => [...pv, ...selectedFiles]);
       }
       if (file.mimeType === "application/vnd.google-apps.presentation") {
-        if (!currentToken) {
-          void messageApi.warning(
-            "認証トークンが無効なため、GIFアニメーションを抽出できません",
-          );
-        }
         const files = await slide2canvas(file.id, currentToken);
         setFiles((pv) => [...pv, ...files]);
       }

--- a/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
+++ b/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
@@ -115,7 +115,7 @@ const MainSlideDisplay: FC<{
           const interval = 1000 / anim.fps;
           if (time - lastTimes[i] >= interval) {
             frameIndices[i] = (frameIndices[i] + 1) % anim.frames.length;
-            lastTimes[i] = time;
+            lastTimes[i] += interval;
           }
         }
 

--- a/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
+++ b/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
@@ -73,7 +73,6 @@ const MainSlideDisplay: FC<{
   onNext: () => void;
 }> = ({ frame, totalFrames, bitmapMap, animationMap, onPrevious, onNext }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const animFrameRef = useRef<number>(0);
 
   useIsomorphicLayoutEffect(() => {
     const canvas = canvasRef.current;
@@ -96,9 +95,9 @@ const MainSlideDisplay: FC<{
       return;
     }
 
-    // Animation loop
+    // Animation loop with independent per-animation timing
     const frameIndices = animations.map(() => 0);
-    let lastTime = 0;
+    const lastTimes = animations.map(() => -1); // -1 = not yet initialized
     let rafId: number;
 
     const draw = (time: number) => {
@@ -109,12 +108,14 @@ const MainSlideDisplay: FC<{
         const anim = animations[i];
         if (anim.frames.length === 0) continue;
 
-        // Advance frame based on fps
-        if (lastTime > 0) {
-          const elapsed = time - lastTime;
+        if (lastTimes[i] < 0) {
+          // First draw: initialize this animation's timer
+          lastTimes[i] = time;
+        } else {
           const interval = 1000 / anim.fps;
-          if (elapsed >= interval) {
+          if (time - lastTimes[i] >= interval) {
             frameIndices[i] = (frameIndices[i] + 1) % anim.frames.length;
+            lastTimes[i] = time;
           }
         }
 
@@ -122,17 +123,10 @@ const MainSlideDisplay: FC<{
         ctx.drawImage(animBitmap, anim.x, anim.y, anim.w, anim.h);
       }
 
-      // Use the slowest fps among all animations for timing
-      const minInterval = Math.min(...animations.map((a) => 1000 / a.fps));
-      if (lastTime === 0 || time - lastTime >= minInterval) {
-        lastTime = time;
-      }
-
       rafId = requestAnimationFrame(draw);
     };
 
     rafId = requestAnimationFrame(draw);
-    animFrameRef.current = rafId;
 
     return () => {
       cancelAnimationFrame(rafId);

--- a/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
+++ b/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
@@ -5,6 +5,15 @@ import { Button, Spin } from "antd";
 import { type FC, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { TbChevronLeft, TbChevronRight } from "react-icons/tb";
 
+type DecodedAnimation = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  fps: number;
+  frames: ImageBitmap[];
+};
+
 const THUMBNAIL_HEIGHT = 128;
 
 // On the client we want to size/draw the canvas before paint to reduce
@@ -59,10 +68,12 @@ const MainSlideDisplay: FC<{
   frame: SlideFrameMeta;
   totalFrames: number;
   bitmapMap: { current: Map<number, ImageBitmap> };
+  animationMap: { current: Map<number, DecodedAnimation[]> };
   onPrevious: () => void;
   onNext: () => void;
-}> = ({ frame, totalFrames, bitmapMap, onPrevious, onNext }) => {
+}> = ({ frame, totalFrames, bitmapMap, animationMap, onPrevious, onNext }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animFrameRef = useRef<number>(0);
 
   useIsomorphicLayoutEffect(() => {
     const canvas = canvasRef.current;
@@ -76,9 +87,57 @@ const MainSlideDisplay: FC<{
     canvas.width = bitmap.width;
     canvas.height = bitmap.height;
 
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
-  }, [frame.index, bitmapMap]);
+    const animations = animationMap.current.get(frame.index);
+
+    if (!animations || animations.length === 0) {
+      // No animation: just draw the base bitmap
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+      return;
+    }
+
+    // Animation loop
+    const frameIndices = animations.map(() => 0);
+    let lastTime = 0;
+    let rafId: number;
+
+    const draw = (time: number) => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+
+      for (let i = 0; i < animations.length; i++) {
+        const anim = animations[i];
+        if (anim.frames.length === 0) continue;
+
+        // Advance frame based on fps
+        if (lastTime > 0) {
+          const elapsed = time - lastTime;
+          const interval = 1000 / anim.fps;
+          if (elapsed >= interval) {
+            frameIndices[i] = (frameIndices[i] + 1) % anim.frames.length;
+          }
+        }
+
+        const animBitmap = anim.frames[frameIndices[i]];
+        ctx.drawImage(animBitmap, anim.x, anim.y, anim.w, anim.h);
+      }
+
+      // Use the slowest fps among all animations for timing
+      const minInterval = Math.min(...animations.map((a) => 1000 / a.fps));
+      if (lastTime === 0 || time - lastTime >= minInterval) {
+        lastTime = time;
+      }
+
+      rafId = requestAnimationFrame(draw);
+    };
+
+    rafId = requestAnimationFrame(draw);
+    animFrameRef.current = rafId;
+
+    return () => {
+      cancelAnimationFrame(rafId);
+    };
+  }, [frame.index, bitmapMap, animationMap]);
 
   return (
     <div className="relative flex items-center justify-center flex-1 rounded overflow-hidden aspect-video">
@@ -155,10 +214,18 @@ const SlideList: FC<{
 const MainView: FC<{
   frames: SlideFrameMeta[];
   bitmapMap: { current: Map<number, ImageBitmap> };
+  animationMap: { current: Map<number, DecodedAnimation[]> };
   selectedIndex: number;
   onPrevious: () => void;
   onNext: () => void;
-}> = ({ frames, bitmapMap, selectedIndex, onPrevious, onNext }) => {
+}> = ({
+  frames,
+  bitmapMap,
+  animationMap,
+  selectedIndex,
+  onPrevious,
+  onNext,
+}) => {
   const selectedFrame = frames[selectedIndex];
 
   return (
@@ -167,6 +234,7 @@ const MainView: FC<{
         frame={selectedFrame}
         totalFrames={frames.length}
         bitmapMap={bitmapMap}
+        animationMap={animationMap}
         onPrevious={onPrevious}
         onNext={onNext}
       />
@@ -197,6 +265,7 @@ const MainView: FC<{
 const SlidePreviewContainer: FC<{
   frames: SlideFrameMeta[];
   bitmapMap: { current: Map<number, ImageBitmap> };
+  animationMap: { current: Map<number, DecodedAnimation[]> };
   selectedIndex: number;
   onSelectFrame: (index: number) => void;
   onPrevious: () => void;
@@ -204,6 +273,7 @@ const SlidePreviewContainer: FC<{
 }> = ({
   frames,
   bitmapMap,
+  animationMap,
   selectedIndex,
   onSelectFrame,
   onPrevious,
@@ -220,6 +290,7 @@ const SlidePreviewContainer: FC<{
       <MainView
         frames={frames}
         bitmapMap={bitmapMap}
+        animationMap={animationMap}
         selectedIndex={selectedIndex}
         onPrevious={onPrevious}
         onNext={onNext}
@@ -228,11 +299,26 @@ const SlidePreviewContainer: FC<{
   );
 };
 
+const imageDataToBitmap = async (data: ImageData): Promise<ImageBitmap> => {
+  try {
+    return await createImageBitmap(data);
+  } catch {
+    const canvas = document.createElement("canvas");
+    canvas.width = data.width;
+    canvas.height = data.height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Canvas 2d context not available");
+    ctx.putImageData(data, 0, 0);
+    return await createImageBitmap(canvas);
+  }
+};
+
 export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
   const [frames, setFrames] = useState<SlideFrameMeta[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const bitmapMap = useRef<Map<number, ImageBitmap>>(new Map());
+  const animationMap = useRef<Map<number, DecodedAnimation[]>>(new Map());
 
   useEffect(() => {
     setFrames(null);
@@ -240,13 +326,19 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
     setSelectedIndex(0);
     for (const bitmap of bitmapMap.current.values()) bitmap.close();
     bitmapMap.current.clear();
+    for (const anims of animationMap.current.values()) {
+      for (const anim of anims) {
+        for (const bm of anim.frames) bm.close();
+      }
+    }
+    animationMap.current.clear();
     const controller = new AbortController();
     const load = async () => {
       let nextMap: Map<number, ImageBitmap> | null = null;
+      const nextAnimMap = new Map<number, DecodedAnimation[]>();
       try {
         const result = await decodeSlides(urls, controller.signal);
         if (!controller.signal.aborted) {
-          // Convert ImageData -> ImageBitmap once, then render synchronously.
           const map = new Map<number, ImageBitmap>();
           const meta: SlideFrameMeta[] = [];
           nextMap = map;
@@ -255,34 +347,42 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
             const f = result.shift();
             if (!f) break;
             if (controller.signal.aborted) break;
-            const sourceImageData = f.imageData;
 
-            const bitmap = await (async () => {
-              // Prefer direct conversion if available.
-              try {
-                return await createImageBitmap(sourceImageData);
-              } catch {
-                // Fallback: draw ImageData into a canvas and convert.
-                const canvas = document.createElement("canvas");
-                canvas.width = sourceImageData.width;
-                canvas.height = sourceImageData.height;
-                const ctx = canvas.getContext("2d");
-                if (!ctx) {
-                  throw new Error(
-                    "OffscreenCanvas/Canvas 2d context not available",
-                  );
-                }
-                ctx.putImageData(sourceImageData, 0, 0);
-                return await createImageBitmap(canvas);
-              }
-            })();
+            const bitmap = await imageDataToBitmap(f.imageData);
             map.set(f.index, bitmap);
-            meta.push({ index: f.index, width: f.width, height: f.height });
+            meta.push({
+              index: f.index,
+              width: f.width,
+              height: f.height,
+              hasAnimations: !!f.animations && f.animations.length > 0,
+            });
+
+            // Convert animation ImageData to ImageBitmap
+            if (f.animations && f.animations.length > 0) {
+              const decodedAnims: DecodedAnimation[] = [];
+              for (const anim of f.animations) {
+                const animBitmaps: ImageBitmap[] = [];
+                for (const frameData of anim.frames) {
+                  if (controller.signal.aborted) break;
+                  animBitmaps.push(await imageDataToBitmap(frameData));
+                }
+                decodedAnims.push({
+                  x: anim.x,
+                  y: anim.y,
+                  w: anim.w,
+                  h: anim.h,
+                  fps: anim.fps,
+                  frames: animBitmaps,
+                });
+              }
+              nextAnimMap.set(f.index, decodedAnims);
+            }
           }
 
           if (!controller.signal.aborted) {
             bitmapMap.current = map;
-            nextMap = null; // ownership transferred to bitmapMap.current
+            animationMap.current = nextAnimMap;
+            nextMap = null;
             setFrames(meta);
           }
         }
@@ -292,9 +392,13 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
           setError("プレビューの読み込みに失敗しました");
         }
       } finally {
-        // If we aborted or failed before transferring ownership, close created bitmaps.
         if (nextMap) {
           for (const bitmap of nextMap.values()) bitmap.close();
+          for (const anims of nextAnimMap.values()) {
+            for (const anim of anims) {
+              for (const bm of anim.frames) bm.close();
+            }
+          }
         }
       }
     };
@@ -303,6 +407,12 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
       controller.abort();
       for (const bitmap of bitmapMap.current.values()) bitmap.close();
       bitmapMap.current.clear();
+      for (const anims of animationMap.current.values()) {
+        for (const anim of anims) {
+          for (const bm of anim.frames) bm.close();
+        }
+      }
+      animationMap.current.clear();
     };
   }, [urls]);
 
@@ -338,6 +448,7 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
     <SlidePreviewContainer
       frames={frames}
       bitmapMap={bitmapMap}
+      animationMap={animationMap}
       selectedIndex={selectedIndex}
       onSelectFrame={setSelectedIndex}
       onPrevious={handlePrevious}

--- a/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
+++ b/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
@@ -355,6 +355,7 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
             if (f.animations && f.animations.length > 0) {
               const decodedAnims: DecodedAnimation[] = [];
               for (const anim of f.animations) {
+                if (controller.signal.aborted) break;
                 const animBitmaps: ImageBitmap[] = [];
                 for (const frameData of anim.frames) {
                   if (controller.signal.aborted) break;

--- a/src/app/(_)/signage/convert/_components/convert.tsx
+++ b/src/app/(_)/signage/convert/_components/convert.tsx
@@ -38,7 +38,9 @@ export const Convert: FC = () => {
         setResults(undefined);
         initRef.current = false;
         console.error("Signage compression failed:", e);
-        void message.error("変換に失敗しました");
+        void message.error(
+          (e instanceof Error && e.message) || "変換に失敗しました",
+        );
       });
   }, [_files, signage, format, router, setResults, resolution]);
   return <></>;

--- a/src/app/(_)/signage/convert/_components/convert.tsx
+++ b/src/app/(_)/signage/convert/_components/convert.tsx
@@ -35,6 +35,8 @@ export const Convert: FC = () => {
         router.push("/convert/upload");
       })
       .catch((e) => {
+        setResults(undefined);
+        initRef.current = false;
         console.error("Signage compression failed:", e);
         void message.error("変換に失敗しました");
       });

--- a/src/app/(_)/signage/convert/_components/convert.tsx
+++ b/src/app/(_)/signage/convert/_components/convert.tsx
@@ -2,6 +2,7 @@
 import { ResultAtom, TargetResolutionAtom } from "@/atoms/convert";
 import { SignageConvertAtom } from "@/atoms/signage-convert";
 import { postCompressSignage } from "@/lib/workerService/postCompressSignage";
+import { message } from "antd";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useRouter } from "next/navigation";
 import { type FC, useEffect, useRef } from "react";
@@ -24,16 +25,19 @@ export const Convert: FC = () => {
     if (initRef.current) return;
     initRef.current = true;
 
-    postCompressSignage(_files, signage, format, 1, 1, resolution).then(
-      (result) => {
+    postCompressSignage(_files, signage, format, 1, 1, resolution)
+      .then((result) => {
         setResults({
           data: result,
           format: format,
           version: 1,
         });
         router.push("/convert/upload");
-      },
-    );
+      })
+      .catch((e) => {
+        console.error("Signage compression failed:", e);
+        void message.error("変換に失敗しました");
+      });
   }, [_files, signage, format, router, setResults, resolution]);
   return <></>;
 };

--- a/src/app/(_)/signage/convert/_components/convert.tsx
+++ b/src/app/(_)/signage/convert/_components/convert.tsx
@@ -38,9 +38,7 @@ export const Convert: FC = () => {
         setResults(undefined);
         initRef.current = false;
         console.error("Signage compression failed:", e);
-        void message.error(
-          (e instanceof Error && e.message) || "変換に失敗しました",
-        );
+        void message.error("変換に失敗しました");
       });
   }, [_files, signage, format, router, setResults, resolution]);
   return <></>;

--- a/src/const/imageFormat.ts
+++ b/src/const/imageFormat.ts
@@ -1,0 +1,1 @@
+export const IMAGE_FORMAT_RGB24 = "RGB24" as const;

--- a/src/lib/eia/compressEIAv1.ts
+++ b/src/lib/eia/compressEIAv1.ts
@@ -6,6 +6,7 @@ import type {
   EIAManifestV1,
   EIASignageManifest,
 } from "@/_types/eia/v1";
+import type { TTextureFormat } from "@/_types/text-zip/formats";
 import type { RawImageObjV1Cropped } from "@/_types/text-zip/v1";
 import { FileSizeLimit } from "@/const/convert";
 import lz4 from "lz4js";
@@ -16,6 +17,7 @@ export type RawAnimationData = {
   w: number;
   h: number;
   fps: number;
+  format: TTextureFormat;
   frames: RawImageObjV1Cropped[];
 };
 
@@ -138,10 +140,16 @@ const compressEIAv1Part = async (
     for (const [slideIndex, anims] of animationMap) {
       const animMetas: EIAAnimationMeta[] = [];
 
-      for (const anim of anims) {
+      for (const [animIndex, anim] of anims.entries()) {
         const frameRefs: EIAAnimationFrameRef[] = [];
         let hasCroppedFrames = false;
-        for (const frame of anim.frames) {
+        usedFormats.add(anim.format);
+        for (const [frameIndex, frame] of anim.frames.entries()) {
+          if (frame.format !== anim.format) {
+            throw new Error(
+              `Animation format mismatch at slide ${slideIndex}, animation ${animIndex}, frame ${frameIndex}: expected "${anim.format}", got "${frame.format}"`,
+            );
+          }
           if (!frame.cropped) {
             // Master frame: store full buffer
             const compressed = Buffer.from(lz4.compress(frame.buffer));
@@ -195,7 +203,7 @@ const compressEIAv1Part = async (
           w: anim.w,
           h: anim.h,
           fps: anim.fps,
-          f: "RGB24",
+          f: anim.format,
           frames: frameRefs,
         });
       }

--- a/src/lib/eia/compressEIAv1.ts
+++ b/src/lib/eia/compressEIAv1.ts
@@ -44,6 +44,12 @@ export const compressEIAv1 = async (
     const compressedPart = await compressEIAv1Part(part, signage, partAnimMap);
 
     if (compressedPart.length > FileSizeLimit) {
+      if (part.length <= 1) {
+        throw new Error(
+          `Slide at index ${part[0]?.index ?? "?"} exceeds file size limit ` +
+            `(${compressedPart.length} > ${FileSizeLimit}) and cannot be split further`,
+        );
+      }
       return compressEIAv1(data, signage, count + 1, stepSize, animationMap);
     }
 

--- a/src/lib/eia/compressEIAv1.ts
+++ b/src/lib/eia/compressEIAv1.ts
@@ -110,6 +110,7 @@ const compressEIAv1Part = async (
   const files: EIAFileV1[] = [];
   const buffer: Buffer[] = [];
   let bufferLength = 0;
+  let usesAnimationFrameSizeV2 = false;
 
   // Track animation metadata per slide index
   const slideAnimMeta = new Map<number, string>();
@@ -183,10 +184,20 @@ const compressEIAv1Part = async (
         const frameRefs: EIAAnimationFrameRef[] = [];
         let hasCroppedFrames = false;
         usedFormats.add(anim.format);
+        const frameWidth = anim.frames[0]?.rect.width ?? anim.w;
+        const frameHeight = anim.frames[0]?.rect.height ?? anim.h;
         for (const [frameIndex, frame] of anim.frames.entries()) {
           if (frame.format !== anim.format) {
             throw new Error(
               `Animation format mismatch at slide ${slideIndex}, animation ${animIndex}, frame ${frameIndex}: expected "${anim.format}", got "${frame.format}"`,
+            );
+          }
+          if (
+            frame.rect.width !== frameWidth ||
+            frame.rect.height !== frameHeight
+          ) {
+            throw new Error(
+              `Animation frame size mismatch at slide ${slideIndex}, animation ${animIndex}, frame ${frameIndex}: expected ${frameWidth}x${frameHeight}, got ${frame.rect.width}x${frame.rect.height}`,
             );
           }
           if (!frame.cropped) {
@@ -236,7 +247,7 @@ const compressEIAv1Part = async (
           usedFeatures.add("Feature:animation-crop");
         }
 
-        animMetas.push({
+        const animMeta: EIAAnimationMeta = {
           x: anim.x,
           y: anim.y,
           w: anim.w,
@@ -244,7 +255,14 @@ const compressEIAv1Part = async (
           fps: anim.fps,
           f: anim.format,
           frames: frameRefs,
-        });
+        };
+        if (frameWidth !== anim.w || frameHeight !== anim.h) {
+          animMeta.fw = frameWidth;
+          animMeta.fh = frameHeight;
+          usesAnimationFrameSizeV2 = true;
+          usedFeatures.add("Feature:animation-frame-size");
+        }
+        animMetas.push(animMeta);
       }
 
       slideAnimMeta.set(slideIndex, JSON.stringify(animMetas));
@@ -269,7 +287,7 @@ const compressEIAv1Part = async (
   const manifest: EIAManifestV1 = {
     t: "eia",
     c: "lz4",
-    v: 1,
+    v: usesAnimationFrameSizeV2 ? 2 : 1,
     f: features,
     e: ["note", ...(usedFeatures.has("Feature:animation") ? ["a"] : [])],
     i: files,

--- a/src/lib/eia/compressEIAv1.ts
+++ b/src/lib/eia/compressEIAv1.ts
@@ -1,4 +1,6 @@
 import type {
+  EIAAnimationFrameRef,
+  EIAAnimationMeta,
   EIAFileV1,
   EIAFileV1CroppedPart,
   EIAManifestV1,
@@ -8,21 +10,41 @@ import type { RawImageObjV1Cropped } from "@/_types/text-zip/v1";
 import { FileSizeLimit } from "@/const/convert";
 import lz4 from "lz4js";
 
+export type RawAnimationData = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  fps: number;
+  frames: { width: number; height: number; buffer: Buffer }[];
+};
+
 export const compressEIAv1 = async (
   data: RawImageObjV1Cropped[],
   signage?: EIASignageManifest,
   count = 1,
   stepSize = 10,
+  animationMap?: Map<number, RawAnimationData[]>,
 ): Promise<Buffer[]> => {
   const partCount = Math.ceil(data.length / (count * stepSize)) * stepSize;
   const result: Buffer[] = [];
 
   for (let i = 0; i < count; i++) {
     const part = data.slice(i * partCount, (i + 1) * partCount);
-    const compressedPart = await compressEIAv1Part(part, signage);
+    // Build animation map for this part's indices
+    let partAnimMap: Map<number, RawAnimationData[]> | undefined;
+    if (animationMap) {
+      partAnimMap = new Map();
+      for (const image of part) {
+        const anims = animationMap.get(image.index);
+        if (anims) partAnimMap.set(image.index, anims);
+      }
+      if (partAnimMap.size === 0) partAnimMap = undefined;
+    }
+    const compressedPart = await compressEIAv1Part(part, signage, partAnimMap);
 
     if (compressedPart.length > FileSizeLimit) {
-      return compressEIAv1(data, signage, count + 1);
+      return compressEIAv1(data, signage, count + 1, stepSize, animationMap);
     }
 
     result.push(compressedPart);
@@ -34,13 +56,21 @@ export const compressEIAv1 = async (
 const compressEIAv1Part = async (
   data: RawImageObjV1Cropped[],
   signage?: EIASignageManifest,
+  animationMap?: Map<number, RawAnimationData[]>,
 ) => {
   const usedFormats = new Set<string>();
+  const usedFeatures = new Set<string>();
   const files: EIAFileV1[] = [];
   const buffer: Buffer[] = [];
   let bufferLength = 0;
 
+  // Track animation metadata per slide index
+  const slideAnimMeta = new Map<number, string>();
+
   for (const image of data) {
+    const ext: { note?: string; a?: string } = {};
+    if (image.note) ext.note = image.note;
+
     if (!image.cropped) {
       const compressed = Buffer.from(lz4.compress(image.buffer));
       buffer.push(compressed);
@@ -51,7 +81,7 @@ const compressEIAv1Part = async (
         f: image.format,
         w: image.rect.width,
         h: image.rect.height,
-        e: image.note ? { note: image.note } : undefined,
+        e: Object.keys(ext).length > 0 ? ext : undefined,
         s: bufferLength,
         l: compressed.length,
         u: image.buffer.length,
@@ -91,18 +121,66 @@ const compressEIAv1Part = async (
       s: bufferLength,
       l: compressed.length,
       u: mergedBuffer.length,
-      e: image.note ? { note: image.note } : undefined,
+      e: Object.keys(ext).length > 0 ? ext : undefined,
       r: parts,
     });
     bufferLength += compressed.length;
   }
 
+  // Append animation frames to data section (after all slide data)
+  if (animationMap) {
+    for (const [slideIndex, anims] of animationMap) {
+      const animMetas: EIAAnimationMeta[] = [];
+
+      for (const anim of anims) {
+        const frameRefs: EIAAnimationFrameRef[] = [];
+        for (const frame of anim.frames) {
+          const compressed = Buffer.from(lz4.compress(frame.buffer));
+          buffer.push(compressed);
+          frameRefs.push({
+            s: bufferLength,
+            l: compressed.length,
+            u: frame.buffer.length,
+          });
+          bufferLength += compressed.length;
+        }
+
+        animMetas.push({
+          x: anim.x,
+          y: anim.y,
+          w: anim.w,
+          h: anim.h,
+          fps: anim.fps,
+          f: "RGB24",
+          frames: frameRefs,
+        });
+      }
+
+      slideAnimMeta.set(slideIndex, JSON.stringify(animMetas));
+      usedFeatures.add("Feature:animation");
+    }
+
+    // Attach animation metadata to corresponding slide items
+    for (const file of files) {
+      const index = Number(file.n);
+      const animJson = slideAnimMeta.get(index);
+      if (animJson) {
+        file.e = { ...file.e, a: animJson };
+      }
+    }
+  }
+
+  const features = [
+    ...Array.from(usedFormats).map((format) => `Format:${format}`),
+    ...Array.from(usedFeatures),
+  ];
+
   const manifest: EIAManifestV1 = {
     t: "eia",
     c: "lz4",
     v: 1,
-    f: Array.from(usedFormats).map((format) => `Format:${format}`),
-    e: ["note"],
+    f: features,
+    e: ["note", ...(usedFeatures.size > 0 ? ["a"] : [])],
     i: files,
     m: signage,
   };

--- a/src/lib/eia/compressEIAv1.ts
+++ b/src/lib/eia/compressEIAv1.ts
@@ -1,3 +1,4 @@
+import type { RawAnimationData } from "@/_types/eia/rawAnimationData";
 import type {
   EIAAnimationFrameRef,
   EIAAnimationMeta,
@@ -6,20 +7,9 @@ import type {
   EIAManifestV1,
   EIASignageManifest,
 } from "@/_types/eia/v1";
-import type { TTextureFormat } from "@/_types/text-zip/formats";
 import type { RawImageObjV1Cropped } from "@/_types/text-zip/v1";
 import { FileSizeLimit } from "@/const/convert";
 import lz4 from "lz4js";
-
-export type RawAnimationData = {
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-  fps: number;
-  format: TTextureFormat;
-  frames: RawImageObjV1Cropped[];
-};
 
 export const compressEIAv1 = async (
   data: RawImageObjV1Cropped[],
@@ -28,11 +18,19 @@ export const compressEIAv1 = async (
   stepSize = 10,
   animationMap?: Map<number, RawAnimationData[]>,
 ): Promise<Buffer[]> => {
-  const partCount = Math.ceil(data.length / (count * stepSize)) * stepSize;
+  if (data.length === 0) return [];
+
+  const normalizedStepSize = Math.max(1, Math.min(stepSize, data.length));
+  const partCount =
+    Math.ceil(data.length / (count * normalizedStepSize)) * normalizedStepSize;
+  const calculatePartCount = (targetCount: number, targetStepSize: number) =>
+    Math.ceil(data.length / (targetCount * targetStepSize)) * targetStepSize;
   const result: Buffer[] = [];
 
   for (let i = 0; i < count; i++) {
     const part = data.slice(i * partCount, (i + 1) * partCount);
+    if (part.length === 0) break;
+
     // Build animation map for this part's indices
     let partAnimMap: Map<number, RawAnimationData[]> | undefined;
     if (animationMap) {
@@ -52,7 +50,48 @@ export const compressEIAv1 = async (
             `(${compressedPart.length} > ${FileSizeLimit}) and cannot be split further`,
         );
       }
-      return compressEIAv1(data, signage, count + 1, stepSize, animationMap);
+
+      const reducedStepSize = Math.max(1, Math.floor(normalizedStepSize / 2));
+      const stepCandidates =
+        reducedStepSize < normalizedStepSize
+          ? [reducedStepSize, normalizedStepSize]
+          : [normalizedStepSize];
+
+      let nextSplit: { count: number; stepSize: number } | null = null;
+      for (const candidateStepSize of stepCandidates) {
+        const startCount =
+          candidateStepSize === normalizedStepSize ? count + 1 : 1;
+        for (
+          let candidateCount = startCount;
+          candidateCount <= data.length;
+          candidateCount++
+        ) {
+          if (
+            calculatePartCount(candidateCount, candidateStepSize) < partCount
+          ) {
+            nextSplit = {
+              count: candidateCount,
+              stepSize: candidateStepSize,
+            };
+            break;
+          }
+        }
+        if (nextSplit) break;
+      }
+
+      if (!nextSplit) {
+        throw new Error(
+          `Unable to split oversized EIA part for slide index ${part[0]?.index ?? "?"}`,
+        );
+      }
+
+      return compressEIAv1(
+        data,
+        signage,
+        nextSplit.count,
+        nextSplit.stepSize,
+        animationMap,
+      );
     }
 
     result.push(compressedPart);

--- a/src/lib/eia/compressEIAv1.ts
+++ b/src/lib/eia/compressEIAv1.ts
@@ -16,7 +16,7 @@ export type RawAnimationData = {
   w: number;
   h: number;
   fps: number;
-  frames: { buffer: Buffer }[];
+  frames: RawImageObjV1Cropped[];
 };
 
 export const compressEIAv1 = async (
@@ -134,15 +134,53 @@ const compressEIAv1Part = async (
 
       for (const anim of anims) {
         const frameRefs: EIAAnimationFrameRef[] = [];
+        let hasCroppedFrames = false;
         for (const frame of anim.frames) {
-          const compressed = Buffer.from(lz4.compress(frame.buffer));
-          buffer.push(compressed);
-          frameRefs.push({
-            s: bufferLength,
-            l: compressed.length,
-            u: frame.buffer.length,
-          });
-          bufferLength += compressed.length;
+          if (!frame.cropped) {
+            // Master frame: store full buffer
+            const compressed = Buffer.from(lz4.compress(frame.buffer));
+            buffer.push(compressed);
+            frameRefs.push({
+              t: "m",
+              s: bufferLength,
+              l: compressed.length,
+              u: frame.buffer.length,
+            });
+            bufferLength += compressed.length;
+          } else {
+            // Cropped frame: concatenate rect buffers, then compress
+            hasCroppedFrames = true;
+            let fileBufferLength = 0;
+            const fileBuffer: Buffer[] = [];
+            const parts: EIAFileV1CroppedPart[] = [];
+            for (const rect of frame.cropped.rects) {
+              fileBuffer.push(rect.buffer);
+              parts.push({
+                x: rect.x,
+                y: rect.y,
+                w: rect.width,
+                h: rect.height,
+                s: fileBufferLength,
+                l: rect.buffer.length,
+              });
+              fileBufferLength += rect.buffer.length;
+            }
+            const mergedBuffer = Buffer.concat(fileBuffer);
+            const compressed = Buffer.from(lz4.compress(mergedBuffer));
+            buffer.push(compressed);
+            frameRefs.push({
+              t: "c",
+              b: frame.cropped.baseIndex,
+              r: parts,
+              s: bufferLength,
+              l: compressed.length,
+              u: mergedBuffer.length,
+            });
+            bufferLength += compressed.length;
+          }
+        }
+        if (hasCroppedFrames) {
+          usedFeatures.add("Feature:animation-crop");
         }
 
         animMetas.push({

--- a/src/lib/eia/compressEIAv1.ts
+++ b/src/lib/eia/compressEIAv1.ts
@@ -16,7 +16,7 @@ export type RawAnimationData = {
   w: number;
   h: number;
   fps: number;
-  frames: { width: number; height: number; buffer: Buffer }[];
+  frames: { buffer: Buffer }[];
 };
 
 export const compressEIAv1 = async (

--- a/src/lib/eia/compressEIAv1.ts
+++ b/src/lib/eia/compressEIAv1.ts
@@ -224,7 +224,7 @@ const compressEIAv1Part = async (
     c: "lz4",
     v: 1,
     f: features,
-    e: ["note", ...(usedFeatures.size > 0 ? ["a"] : [])],
+    e: ["note", ...(usedFeatures.has("Feature:animation") ? ["a"] : [])],
     i: files,
     m: signage,
   };

--- a/src/lib/google/emuToPixel.ts
+++ b/src/lib/google/emuToPixel.ts
@@ -1,3 +1,9 @@
+import type {
+  CanvasSize,
+  PageSize,
+  PixelRect,
+} from "@/_types/lib/google/slideGeometry";
+
 /**
  * Convert Google Slides EMU (English Metric Units) coordinates
  * to pixel coordinates on the rendered PDF canvas.
@@ -12,21 +18,11 @@ type EmuRect = {
   h: number;
 };
 
-type PageSizeEmu = {
-  width: number;
-  height: number;
-};
-
-type CanvasSize = {
-  width: number;
-  height: number;
-};
-
 export const emuToPixelRect = (
   emu: EmuRect,
-  pageSize: PageSizeEmu,
+  pageSize: PageSize,
   canvasSize: CanvasSize,
-): { x: number; y: number; w: number; h: number } => {
+): PixelRect => {
   const scaleX = canvasSize.width / pageSize.width;
   const scaleY = canvasSize.height / pageSize.height;
   return {

--- a/src/lib/google/emuToPixel.ts
+++ b/src/lib/google/emuToPixel.ts
@@ -1,0 +1,38 @@
+/**
+ * Convert Google Slides EMU (English Metric Units) coordinates
+ * to pixel coordinates on the rendered PDF canvas.
+ *
+ * The PDF is rendered to fit within 3840x2160 (matching pdfPage2canvas logic).
+ */
+
+type EmuRect = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+};
+
+type PageSizeEmu = {
+  width: number;
+  height: number;
+};
+
+type CanvasSize = {
+  width: number;
+  height: number;
+};
+
+export const emuToPixelRect = (
+  emu: EmuRect,
+  pageSize: PageSizeEmu,
+  canvasSize: CanvasSize,
+): { x: number; y: number; w: number; h: number } => {
+  const scaleX = canvasSize.width / pageSize.width;
+  const scaleY = canvasSize.height / pageSize.height;
+  return {
+    x: Math.round(emu.x * scaleX),
+    y: Math.round(emu.y * scaleY),
+    w: Math.round(emu.w * scaleX),
+    h: Math.round(emu.h * scaleY),
+  };
+};

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -10,6 +10,7 @@ import { type ParsedFrame, decompressFrames, parseGIF } from "gifuct-js";
 import { emuToPixelRect } from "./emuToPixel";
 
 const MAX_GIF_DIMENSION = 256;
+const MAX_SOURCE_GIF_DIMENSION = 4096;
 const MAX_STORED_FRAME_DIMENSION = 512;
 const MAX_FRAMES = 60;
 const TARGET_FPS = 2;
@@ -363,6 +364,21 @@ export const extractGifAnimations = async (
       }
 
       const gif = parseGIF(buffer);
+      const gifWidth = gif.lsd.width;
+      const gifHeight = gif.lsd.height;
+      if (
+        !(gifWidth > 0) ||
+        !(gifHeight > 0) ||
+        gifWidth > MAX_SOURCE_GIF_DIMENSION ||
+        gifHeight > MAX_SOURCE_GIF_DIMENSION
+      ) {
+        console.warn(
+          `extractGifAnimations: GIF dimensions out of range (${gifWidth}x${gifHeight}), skipping`,
+        );
+        animatedGifCandidatesRaw.push(null);
+        continue;
+      }
+
       const rawFrames = decompressFrames(gif, true);
       if (rawFrames.length <= 1) {
         animatedGifCandidatesRaw.push(null); // Static GIF, skip
@@ -373,8 +389,8 @@ export const extractGifAnimations = async (
         element,
         pixelRect,
         rawFrames,
-        gifWidth: gif.lsd.width,
-        gifHeight: gif.lsd.height,
+        gifWidth,
+        gifHeight,
       } satisfies AnimatedGifCandidate);
     } catch (e) {
       console.warn("Failed to extract GIF animation:", e);

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -1,5 +1,10 @@
 import type { SelectedFileAnimation } from "@/_types/file-picker";
 import type { SlidePageElement } from "@/_types/google-slides-api";
+import type {
+  CanvasSize,
+  PageSize,
+  PixelRect,
+} from "@/_types/lib/google/slideGeometry";
 import { type ParsedFrame, decompressFrames, parseGIF } from "gifuct-js";
 import { emuToPixelRect } from "./emuToPixel";
 
@@ -7,16 +12,6 @@ const MAX_GIF_DIMENSION = 256;
 const MAX_FRAMES = 60;
 const TARGET_FPS = 2;
 const TARGET_FRAME_INTERVAL_MS = 1000 / TARGET_FPS;
-
-type PageSize = {
-  width: number;
-  height: number;
-};
-
-type CanvasSize = {
-  width: number;
-  height: number;
-};
 
 const isGif = (buffer: ArrayBuffer): boolean => {
   if (buffer.byteLength < 6) return false;
@@ -42,24 +37,21 @@ const clampDimensions = (w: number, h: number): { w: number; h: number } => {
 const sampleFrameIndices = (frames: ParsedFrame[]): number[] => {
   if (frames.length <= 1) return [0];
 
-  const indices: number[] = [0];
-  // Start accumulation with frame 0's own display time so subsequent
-  // thresholds are measured from the moment frame 0 first appears.
-  let accumulatedMs = frames[0].delay || 100;
-  let nextSampleMs = TARGET_FRAME_INTERVAL_MS;
+  const indices: number[] = [];
+  let accumulatedMs = 0;
+  let nextSampleMs = 0;
 
-  for (let i = 1; i < frames.length; i++) {
+  for (let i = 0; i < frames.length && indices.length < MAX_FRAMES; i++) {
     // gifuct-js converts GCE delay (centiseconds) to milliseconds via × 10;
     // fall back to 100ms if the field is missing or zero.
     accumulatedMs += frames[i].delay || 100;
     // Emit this frame once per interval bucket it covers
-    while (accumulatedMs >= nextSampleMs && indices.length < MAX_FRAMES) {
+    while (accumulatedMs > nextSampleMs && indices.length < MAX_FRAMES) {
       indices.push(i);
       nextSampleMs += TARGET_FRAME_INTERVAL_MS;
     }
-    if (indices.length >= MAX_FRAMES) break;
   }
-  return indices;
+  return indices.length > 0 ? indices : [0];
 };
 
 /**
@@ -142,20 +134,21 @@ const buildComposedFrames = (
     if (output.length >= MAX_FRAMES) break;
   }
 
-  compositionCanvas.close();
   return output;
 };
+
+const rectsIntersect = (a: PixelRect, b: PixelRect): boolean =>
+  a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
 
 const compositeWithBackground = (
   baseSlideCanvas: OffscreenCanvas,
   gifFrameCanvas: OffscreenCanvas,
-  pixelRect: { x: number; y: number; w: number; h: number },
+  pixelRect: PixelRect,
 ): OffscreenCanvas => {
   const composited = new OffscreenCanvas(pixelRect.w, pixelRect.h);
   const ctx = composited.getContext("2d");
   if (!ctx) throw new Error("Cannot get 2d context");
 
-  // Draw base slide region as background
   ctx.drawImage(
     baseSlideCanvas,
     pixelRect.x,
@@ -167,8 +160,6 @@ const compositeWithBackground = (
     pixelRect.w,
     pixelRect.h,
   );
-
-  // Overlay GIF frame (transparent areas will show base)
   ctx.drawImage(gifFrameCanvas, 0, 0, pixelRect.w, pixelRect.h);
 
   return composited;
@@ -186,60 +177,120 @@ export const extractGifAnimations = async (
     return [];
   }
 
-  const imageElements = pageElements.filter(
-    (el) =>
-      el.image?.contentUrl &&
-      el.size &&
-      el.transform &&
-      // Skip rotated/sheared/flipped elements — affine transform not supported
-      !el.transform.shearX &&
-      !el.transform.shearY,
+  const imageElements = pageElements
+    .map((element) => {
+      const contentUrl = element.image?.contentUrl;
+      const size = element.size;
+      const transform = element.transform;
+      const scaleX = transform?.scaleX;
+      const scaleY = transform?.scaleY;
+      if (
+        !contentUrl ||
+        !size ||
+        !transform ||
+        // Skip rotated/sheared/flipped elements — only positive scale without shear is supported
+        !!transform.shearX ||
+        !!transform.shearY ||
+        typeof scaleX !== "number" ||
+        scaleX <= 0 ||
+        typeof scaleY !== "number" ||
+        scaleY <= 0
+      ) {
+        return null;
+      }
+
+      const emuRect = {
+        x: transform.translateX ?? 0,
+        y: transform.translateY ?? 0,
+        w: size.width.magnitude * scaleX,
+        h: size.height.magnitude * scaleY,
+      };
+      const pixelRect = emuToPixelRect(emuRect, pageSize, canvasSize);
+      if (pixelRect.w <= 0 || pixelRect.h <= 0) return null;
+
+      return { element, pixelRect };
+    })
+    .filter(
+      (
+        el,
+      ): el is {
+        element: SlidePageElement;
+        pixelRect: PixelRect;
+      } => el !== null,
+    );
+
+  type AnimatedGifCandidate = {
+    pixelRect: PixelRect;
+    rawFrames: ParsedFrame[];
+    gifWidth: number;
+    gifHeight: number;
+  };
+
+  const animatedGifCandidates = (
+    await Promise.all(
+      imageElements.map(async ({ element, pixelRect }) => {
+        const contentUrl = element.image?.contentUrl;
+        if (!contentUrl) return null;
+
+        try {
+          const response = await fetch(contentUrl, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          if (!response.ok) return null;
+
+          const buffer = await response.arrayBuffer();
+          if (!isGif(buffer)) return null;
+
+          const gif = parseGIF(buffer);
+          const rawFrames = decompressFrames(gif, true);
+          if (rawFrames.length <= 1) return null; // Static GIF, skip
+
+          return {
+            pixelRect,
+            rawFrames,
+            gifWidth: gif.lsd.width,
+            gifHeight: gif.lsd.height,
+          } satisfies AnimatedGifCandidate;
+        } catch (e) {
+          console.warn("Failed to extract GIF animation:", e);
+          return null;
+        }
+      }),
+    )
+  ).filter(
+    (candidate): candidate is AnimatedGifCandidate => candidate !== null,
   );
 
-  const results = await Promise.all(
-    imageElements.map(async (element) => {
-      const contentUrl = element.image?.contentUrl;
-      if (!contentUrl) return null;
+  const intersectingElementIndices = new Set<number>();
+  for (let i = 0; i < animatedGifCandidates.length; i++) {
+    for (let j = i + 1; j < animatedGifCandidates.length; j++) {
+      if (
+        rectsIntersect(
+          animatedGifCandidates[i].pixelRect,
+          animatedGifCandidates[j].pixelRect,
+        )
+      ) {
+        intersectingElementIndices.add(i);
+        intersectingElementIndices.add(j);
+      }
+    }
+  }
 
+  if (intersectingElementIndices.size > 0) {
+    console.warn(
+      `extractGifAnimations: skipping ${intersectingElementIndices.size} intersecting animated GIF element(s); overlapping animated rects are not supported with RGB24 animation encoding`,
+    );
+  }
+
+  const nonIntersectingAnimatedCandidates = animatedGifCandidates.filter(
+    (_, index) => !intersectingElementIndices.has(index),
+  );
+
+  const results = nonIntersectingAnimatedCandidates
+    .map(({ pixelRect, rawFrames, gifWidth, gifHeight }) => {
       try {
-        const response = await fetch(contentUrl, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (!response.ok) return null;
-
-        const buffer = await response.arrayBuffer();
-        if (!isGif(buffer)) return null;
-
-        const gif = parseGIF(buffer);
-        const rawFrames = decompressFrames(gif, true);
-        if (rawFrames.length <= 1) return null; // Static GIF, skip
-
         const sampleIndices = sampleFrameIndices(rawFrames);
-
-        const gifWidth = gif.lsd.width;
-        const gifHeight = gif.lsd.height;
         const { w: targetW, h: targetH } = clampDimensions(gifWidth, gifHeight);
-
-        // Compute pixel rect on the rendered slide
-        const sizeW = element.size?.width.magnitude ?? 0;
-        const sizeH = element.size?.height.magnitude ?? 0;
-        const scaleX = element.transform?.scaleX ?? 1;
-        const scaleY = element.transform?.scaleY ?? 1;
-        const translateX = element.transform?.translateX ?? 0;
-        const translateY = element.transform?.translateY ?? 0;
-
-        const emuRect = {
-          x: translateX,
-          y: translateY,
-          w: sizeW * scaleX,
-          h: sizeH * scaleY,
-        };
-
-        const pixelRect = emuToPixelRect(
-          emuRect,
-          { width: pageSize.width, height: pageSize.height },
-          canvasSize,
-        );
 
         // Build composed GIF frames with proper inter-frame compositing
         const composedFrames = buildComposedFrames(
@@ -250,18 +301,9 @@ export const extractGifAnimations = async (
           targetW,
           targetH,
         );
-
-        // Composite each frame with base slide background (handles transparent GIFs)
-        // Close intermediate composed frames after compositing — they are no longer needed
-        const frames = composedFrames.map((frameCanvas) => {
-          const composited = compositeWithBackground(
-            baseSlideCanvas,
-            frameCanvas,
-            pixelRect,
-          );
-          frameCanvas.close();
-          return composited;
-        });
+        const frames = composedFrames.map((frameCanvas) =>
+          compositeWithBackground(baseSlideCanvas, frameCanvas, pixelRect),
+        );
 
         return {
           x: pixelRect.x,
@@ -272,11 +314,11 @@ export const extractGifAnimations = async (
           frames,
         } satisfies SelectedFileAnimation;
       } catch (e) {
-        console.warn("Failed to extract GIF animation:", e);
+        console.warn("Failed to build composed GIF frames:", e);
         return null;
       }
-    }),
-  );
+    })
+    .filter((r): r is SelectedFileAnimation => r !== null);
 
-  return results.filter((r): r is SelectedFileAnimation => r !== null);
+  return results;
 };

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -35,14 +35,14 @@ const clampDimensions = (w: number, h: number): { w: number; h: number } => {
 };
 
 /**
- * Returns the set of frame indices to output at TARGET_FPS by accumulating
- * per-frame delays. All frames must still be composited in order; only frames
- * at these indices are written to output.
+ * Returns an ordered array of frame indices to output at TARGET_FPS.
+ * A single source frame may appear multiple times if its delay spans
+ * several TARGET_FRAME_INTERVAL_MS buckets, preserving correct playback tempo.
  */
-const sampleFrameIndices = (frames: ParsedFrame[]): Set<number> => {
-  if (frames.length <= 1) return new Set([0]);
+const sampleFrameIndices = (frames: ParsedFrame[]): number[] => {
+  if (frames.length <= 1) return [0];
 
-  const indices = new Set<number>([0]);
+  const indices: number[] = [0];
   // Start accumulation with frame 0's own display time so subsequent
   // thresholds are measured from the moment frame 0 first appears.
   let accumulatedMs = frames[0].delay || 100;
@@ -52,11 +52,12 @@ const sampleFrameIndices = (frames: ParsedFrame[]): Set<number> => {
     // gifuct-js converts GCE delay (centiseconds) to milliseconds via × 10;
     // fall back to 100ms if the field is missing or zero.
     accumulatedMs += frames[i].delay || 100;
-    if (accumulatedMs >= nextSampleMs) {
-      indices.add(i);
+    // Emit this frame once per interval bucket it covers
+    while (accumulatedMs >= nextSampleMs && indices.length < MAX_FRAMES) {
+      indices.push(i);
       nextSampleMs += TARGET_FRAME_INTERVAL_MS;
-      if (indices.size >= MAX_FRAMES) break;
     }
+    if (indices.length >= MAX_FRAMES) break;
   }
   return indices;
 };
@@ -68,7 +69,7 @@ const sampleFrameIndices = (frames: ParsedFrame[]): Set<number> => {
  */
 const buildComposedFrames = (
   allFrames: ParsedFrame[],
-  sampleIndices: Set<number>,
+  sampleIndices: number[],
   gifWidth: number,
   gifHeight: number,
   targetW: number,
@@ -79,6 +80,7 @@ const buildComposedFrames = (
   if (!compositionCtx) throw new Error("Cannot get 2d context");
 
   const output: OffscreenCanvas[] = [];
+  let samplePtr = 0; // pointer into sampleIndices array
   let prevDisposal = 0;
   let prevDims: ParsedFrame["dims"] | null = null;
   let prevSnapshot: ImageData | null = null;
@@ -126,12 +128,15 @@ const buildComposedFrames = (
     prevDisposal = disposal;
     prevDims = frame.dims;
 
-    if (sampleIndices.has(i)) {
+    // Output all samples that reference this frame index (may be >1 for long-delay frames)
+    while (samplePtr < sampleIndices.length && sampleIndices[samplePtr] === i) {
       const result = new OffscreenCanvas(targetW, targetH);
       const resultCtx = result.getContext("2d");
       if (!resultCtx) throw new Error("Cannot get 2d context");
       resultCtx.drawImage(compositionCanvas, 0, 0, targetW, targetH);
       output.push(result);
+      samplePtr++;
+      if (output.length >= MAX_FRAMES) break;
     }
 
     if (output.length >= MAX_FRAMES) break;
@@ -182,7 +187,13 @@ export const extractGifAnimations = async (
   }
 
   const imageElements = pageElements.filter(
-    (el) => el.image?.contentUrl && el.size && el.transform,
+    (el) =>
+      el.image?.contentUrl &&
+      el.size &&
+      el.transform &&
+      // Skip rotated/sheared/flipped elements — affine transform not supported
+      !el.transform.shearX &&
+      !el.transform.shearY,
   );
 
   const animations: SelectedFileAnimation[] = [];

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -43,7 +43,9 @@ const sampleFrameIndices = (frames: ParsedFrame[]): Set<number> => {
   if (frames.length <= 1) return new Set([0]);
 
   const indices = new Set<number>([0]);
-  let accumulatedMs = 0;
+  // Start accumulation with frame 0's own display time so subsequent
+  // thresholds are measured from the moment frame 0 first appears.
+  let accumulatedMs = frames[0].delay || 100;
   let nextSampleMs = TARGET_FRAME_INTERVAL_MS;
 
   for (let i = 1; i < frames.length; i++) {

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -133,6 +133,7 @@ const buildComposedFrames = (
     if (output.length >= MAX_FRAMES) break;
   }
 
+  compositionCanvas.close();
   return output;
 };
 
@@ -237,9 +238,16 @@ export const extractGifAnimations = async (
       );
 
       // Composite each frame with base slide background (handles transparent GIFs)
-      const frames = composedFrames.map((frameCanvas) =>
-        compositeWithBackground(baseSlideCanvas, frameCanvas, pixelRect),
-      );
+      // Close intermediate composed frames after compositing — they are no longer needed
+      const frames = composedFrames.map((frameCanvas) => {
+        const composited = compositeWithBackground(
+          baseSlideCanvas,
+          frameCanvas,
+          pixelRect,
+        );
+        frameCanvas.close();
+        return composited;
+      });
 
       animations.push({
         x: pixelRect.x,

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -9,6 +9,23 @@ import type {
 import { type ParsedFrame, decompressFrames, parseGIF } from "gifuct-js";
 import { emuToPixelRect } from "./emuToPixel";
 
+const TRUSTED_HOSTNAMES = [
+  ".google.com",
+  ".googleapis.com",
+  ".googleusercontent.com",
+];
+
+const isTrustedOrigin = (url: string): boolean => {
+  try {
+    const { hostname } = new URL(url);
+    return TRUSTED_HOSTNAMES.some(
+      (suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix),
+    );
+  } catch {
+    return false;
+  }
+};
+
 const MAX_GIF_DIMENSION = 256;
 const MAX_SOURCE_GIF_DIMENSION = 4096;
 const MAX_STORED_FRAME_DIMENSION = 512;
@@ -327,77 +344,67 @@ export const extractGifAnimations = async (
       } => el !== null,
     );
 
-  const animatedGifCandidatesRaw: (AnimatedGifCandidate | null)[] = [];
-  for (const { element, pixelRect } of imageElements) {
-    const contentUrl = element.image?.contentUrl;
-    if (!contentUrl) {
-      animatedGifCandidatesRaw.push(null);
-      continue;
-    }
-    try {
-      const rangeSniffResponse = await fetch(contentUrl, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Range: "bytes=0-5",
-        },
-      });
-      if (!rangeSniffResponse.ok) {
-        animatedGifCandidatesRaw.push(null);
-        continue;
-      }
+  const animatedGifCandidatesRaw = await Promise.all(
+    imageElements.map(
+      async ({ element, pixelRect }): Promise<AnimatedGifCandidate | null> => {
+        const contentUrl = element.image?.contentUrl;
+        if (!contentUrl || !isTrustedOrigin(contentUrl)) return null;
+        try {
+          const rangeSniffResponse = await fetch(contentUrl, {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              Range: "bytes=0-5",
+            },
+          });
+          if (!rangeSniffResponse.ok) return null;
 
-      const headerBuffer = await rangeSniffResponse.arrayBuffer();
-      if (!isGif(headerBuffer)) {
-        animatedGifCandidatesRaw.push(null);
-        continue;
-      }
+          const headerBuffer = await rangeSniffResponse.arrayBuffer();
+          if (!isGif(headerBuffer)) return null;
 
-      let buffer = headerBuffer;
-      if (rangeSniffResponse.status === 206 || headerBuffer.byteLength <= 6) {
-        const fullResponse = await fetch(contentUrl, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (!fullResponse.ok) {
-          animatedGifCandidatesRaw.push(null);
-          continue;
+          let buffer = headerBuffer;
+          if (
+            rangeSniffResponse.status === 206 ||
+            headerBuffer.byteLength <= 6
+          ) {
+            const fullResponse = await fetch(contentUrl, {
+              headers: { Authorization: `Bearer ${token}` },
+            });
+            if (!fullResponse.ok) return null;
+            buffer = await fullResponse.arrayBuffer();
+          }
+
+          const gif = parseGIF(buffer);
+          const gifWidth = gif.lsd.width;
+          const gifHeight = gif.lsd.height;
+          if (
+            !(gifWidth > 0) ||
+            !(gifHeight > 0) ||
+            gifWidth > MAX_SOURCE_GIF_DIMENSION ||
+            gifHeight > MAX_SOURCE_GIF_DIMENSION
+          ) {
+            console.warn(
+              `extractGifAnimations: GIF dimensions out of range (${gifWidth}x${gifHeight}), skipping`,
+            );
+            return null;
+          }
+
+          const rawFrames = decompressFrames(gif, true);
+          if (rawFrames.length <= 1) return null; // Static GIF, skip
+
+          return {
+            element,
+            pixelRect,
+            rawFrames,
+            gifWidth,
+            gifHeight,
+          } satisfies AnimatedGifCandidate;
+        } catch (e) {
+          console.warn("Failed to extract GIF animation:", e);
+          return null;
         }
-        buffer = await fullResponse.arrayBuffer();
-      }
-
-      const gif = parseGIF(buffer);
-      const gifWidth = gif.lsd.width;
-      const gifHeight = gif.lsd.height;
-      if (
-        !(gifWidth > 0) ||
-        !(gifHeight > 0) ||
-        gifWidth > MAX_SOURCE_GIF_DIMENSION ||
-        gifHeight > MAX_SOURCE_GIF_DIMENSION
-      ) {
-        console.warn(
-          `extractGifAnimations: GIF dimensions out of range (${gifWidth}x${gifHeight}), skipping`,
-        );
-        animatedGifCandidatesRaw.push(null);
-        continue;
-      }
-
-      const rawFrames = decompressFrames(gif, true);
-      if (rawFrames.length <= 1) {
-        animatedGifCandidatesRaw.push(null); // Static GIF, skip
-        continue;
-      }
-
-      animatedGifCandidatesRaw.push({
-        element,
-        pixelRect,
-        rawFrames,
-        gifWidth,
-        gifHeight,
-      } satisfies AnimatedGifCandidate);
-    } catch (e) {
-      console.warn("Failed to extract GIF animation:", e);
-      animatedGifCandidatesRaw.push(null);
-    }
-  }
+      },
+    ),
+  );
 
   const animatedGifCandidates = animatedGifCandidatesRaw.filter(
     (candidate): candidate is AnimatedGifCandidate => candidate !== null,

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -47,6 +47,8 @@ const sampleFrameIndices = (frames: ParsedFrame[]): Set<number> => {
   let nextSampleMs = TARGET_FRAME_INTERVAL_MS;
 
   for (let i = 1; i < frames.length; i++) {
+    // gifuct-js converts GCE delay (centiseconds) to milliseconds via × 10;
+    // fall back to 100ms if the field is missing or zero.
     accumulatedMs += frames[i].delay || 100;
     if (accumulatedMs >= nextSampleMs) {
       indices.add(i);

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -1,5 +1,6 @@
 import type { SelectedFileAnimation } from "@/_types/file-picker";
 import type { SlidePageElement } from "@/_types/google-slides-api";
+import type { AnimatedGifCandidate } from "@/_types/lib/google/gifAnimation";
 import type {
   CanvasSize,
   PageSize,
@@ -250,17 +251,6 @@ const buildComposedFrames = (
 const rectsIntersect = (a: PixelRect, b: PixelRect): boolean =>
   a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
 
-const hasTransparency = (canvas: OffscreenCanvas): boolean => {
-  const ctx = canvas.getContext("2d");
-  if (!ctx) throw new Error("Cannot get 2d context");
-  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-  const data = imageData.data;
-  for (let i = 3; i < data.length; i += 4) {
-    if (data[i] < 255) return true;
-  }
-  return false;
-};
-
 const compositeWithBackground = (
   baseSlideCanvas: OffscreenCanvas,
   gifFrameCanvas: OffscreenCanvas,
@@ -334,14 +324,6 @@ export const extractGifAnimations = async (
         pixelRect: PixelRect;
       } => el !== null,
     );
-
-  type AnimatedGifCandidate = {
-    element: SlidePageElement;
-    pixelRect: PixelRect;
-    rawFrames: ParsedFrame[];
-    gifWidth: number;
-    gifHeight: number;
-  };
 
   const animatedGifCandidatesRaw: (AnimatedGifCandidate | null)[] = [];
   for (const { element, pixelRect } of imageElements) {
@@ -471,14 +453,6 @@ export const extractGifAnimations = async (
           targetW,
           targetH,
         );
-        if (
-          composedFrames.some((frameCanvas) => hasTransparency(frameCanvas))
-        ) {
-          console.warn(
-            "extractGifAnimations: skipping animated GIF element with transparent pixels; transparency is not supported with RGB24 animation encoding",
-          );
-          return null;
-        }
         const frames = composedFrames.map((frameCanvas) =>
           compositeWithBackground(
             baseSlideCanvas,

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -30,6 +30,7 @@ const MAX_GIF_DIMENSION = 256;
 const MAX_SOURCE_GIF_DIMENSION = 4096;
 const MAX_STORED_FRAME_DIMENSION = 512;
 const MAX_FRAMES = 60;
+const MAX_SOURCE_FRAMES = 500;
 const TARGET_FPS = 2;
 const TARGET_FRAME_INTERVAL_MS = 1000 / TARGET_FPS;
 
@@ -388,6 +389,13 @@ export const extractGifAnimations = async (
             return null;
           }
 
+          if (gif.frames.length > MAX_SOURCE_FRAMES) {
+            console.warn(
+              `extractGifAnimations: too many frames (${gif.frames.length}), skipping`,
+            );
+            return null;
+          }
+
           const rawFrames = decompressFrames(gif, true);
           if (rawFrames.length <= 1) return null; // Static GIF, skip
 
@@ -477,15 +485,17 @@ export const extractGifAnimations = async (
           targetW,
           targetH,
         );
-        const frames = composedFrames.map((frameCanvas) =>
-          compositeWithBackground(
+        const frames = composedFrames.map((frameCanvas) => {
+          const result = compositeWithBackground(
             baseSlideCanvas,
             frameCanvas,
             pixelRect,
             storedFrameW,
             storedFrameH,
-          ),
-        );
+          );
+          frameCanvas.width = 0;
+          return result;
+        });
 
         return {
           x: pixelRect.x,

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -19,6 +19,7 @@ type CanvasSize = {
 };
 
 const isGif = (buffer: ArrayBuffer): boolean => {
+  if (buffer.byteLength < 6) return false;
   const header = new Uint8Array(buffer, 0, 6);
   const sig = String.fromCharCode(...header);
   return sig === "GIF87a" || sig === "GIF89a";
@@ -33,52 +34,106 @@ const clampDimensions = (w: number, h: number): { w: number; h: number } => {
   };
 };
 
-const sampleFramesAt2Fps = (frames: ParsedFrame[]): ParsedFrame[] => {
-  if (frames.length <= 1) return frames;
+/**
+ * Returns the set of frame indices to output at TARGET_FPS by accumulating
+ * per-frame delays. All frames must still be composited in order; only frames
+ * at these indices are written to output.
+ */
+const sampleFrameIndices = (frames: ParsedFrame[]): Set<number> => {
+  if (frames.length <= 1) return new Set([0]);
 
-  const sampled: ParsedFrame[] = [frames[0]];
+  const indices = new Set<number>([0]);
   let accumulatedMs = 0;
   let nextSampleMs = TARGET_FRAME_INTERVAL_MS;
 
   for (let i = 1; i < frames.length; i++) {
     accumulatedMs += frames[i].delay || 100;
     if (accumulatedMs >= nextSampleMs) {
-      sampled.push(frames[i]);
+      indices.add(i);
       nextSampleMs += TARGET_FRAME_INTERVAL_MS;
-      if (sampled.length >= MAX_FRAMES) break;
+      if (indices.size >= MAX_FRAMES) break;
     }
   }
-  return sampled;
+  return indices;
 };
 
-const gifFrameToCanvas = (
-  frame: ParsedFrame,
+/**
+ * Compose all GIF frames in order, maintaining a persistent canvas to handle
+ * delta-frame (partial update) GIFs and GIF disposal methods correctly.
+ * Outputs only frames at the given sample indices, resized to targetW × targetH.
+ */
+const buildComposedFrames = (
+  allFrames: ParsedFrame[],
+  sampleIndices: Set<number>,
   gifWidth: number,
   gifHeight: number,
   targetW: number,
   targetH: number,
-): OffscreenCanvas => {
-  // Draw the decompressed frame patch onto a full-size GIF canvas
-  const fullCanvas = new OffscreenCanvas(gifWidth, gifHeight);
-  const fullCtx = fullCanvas.getContext("2d");
-  if (!fullCtx) throw new Error("Cannot get 2d context");
+): OffscreenCanvas[] => {
+  const compositionCanvas = new OffscreenCanvas(gifWidth, gifHeight);
+  const compositionCtx = compositionCanvas.getContext("2d");
+  if (!compositionCtx) throw new Error("Cannot get 2d context");
 
-  const imageData = fullCtx.createImageData(
-    frame.dims.width,
-    frame.dims.height,
-  );
-  imageData.data.set(frame.patch);
-  fullCtx.putImageData(imageData, frame.dims.left, frame.dims.top);
+  const output: OffscreenCanvas[] = [];
+  let prevDisposal = 0;
+  let prevDims: ParsedFrame["dims"] | null = null;
+  let prevSnapshot: ImageData | null = null;
 
-  // Resize to target dimensions
-  if (targetW === gifWidth && targetH === gifHeight) {
-    return fullCanvas;
+  for (let i = 0; i < allFrames.length; i++) {
+    const frame = allFrames[i];
+    const disposal = frame.disposalType ?? 0;
+
+    // Apply previous frame's disposal before drawing current patch
+    if (prevDims) {
+      if (prevDisposal === 2) {
+        // Restore to background (clear to transparent)
+        compositionCtx.clearRect(
+          prevDims.left,
+          prevDims.top,
+          prevDims.width,
+          prevDims.height,
+        );
+      } else if (prevDisposal === 3 && prevSnapshot) {
+        // Restore to what was there before the previous frame was drawn
+        compositionCtx.putImageData(prevSnapshot, prevDims.left, prevDims.top);
+        prevSnapshot = null;
+      }
+      // disposal 0 or 1: leave canvas as-is
+    }
+
+    // Snapshot current region if this frame uses "restore to previous" on disposal
+    if (disposal === 3) {
+      prevSnapshot = compositionCtx.getImageData(
+        frame.dims.left,
+        frame.dims.top,
+        frame.dims.width,
+        frame.dims.height,
+      );
+    }
+
+    // Draw current frame's patch onto the persistent composition canvas
+    const imageData = compositionCtx.createImageData(
+      frame.dims.width,
+      frame.dims.height,
+    );
+    imageData.data.set(frame.patch);
+    compositionCtx.putImageData(imageData, frame.dims.left, frame.dims.top);
+
+    prevDisposal = disposal;
+    prevDims = frame.dims;
+
+    if (sampleIndices.has(i)) {
+      const result = new OffscreenCanvas(targetW, targetH);
+      const resultCtx = result.getContext("2d");
+      if (!resultCtx) throw new Error("Cannot get 2d context");
+      resultCtx.drawImage(compositionCanvas, 0, 0, targetW, targetH);
+      output.push(result);
+    }
+
+    if (output.length >= MAX_FRAMES) break;
   }
-  const resized = new OffscreenCanvas(targetW, targetH);
-  const resizedCtx = resized.getContext("2d");
-  if (!resizedCtx) throw new Error("Cannot get 2d context");
-  resizedCtx.drawImage(fullCanvas, 0, 0, targetW, targetH);
-  return resized;
+
+  return output;
 };
 
 const compositeWithBackground = (
@@ -116,6 +171,11 @@ export const extractGifAnimations = async (
   baseSlideCanvas: OffscreenCanvas,
   token: string,
 ): Promise<SelectedFileAnimation[]> => {
+  if (!token) {
+    console.warn("extractGifAnimations: empty token, skipping GIF extraction");
+    return [];
+  }
+
   const imageElements = pageElements.filter(
     (el) => el.image?.contentUrl && el.size && el.transform,
   );
@@ -139,7 +199,7 @@ export const extractGifAnimations = async (
       const rawFrames = decompressFrames(gif, true);
       if (rawFrames.length <= 1) continue; // Static GIF, skip
 
-      const sampledFrames = sampleFramesAt2Fps(rawFrames);
+      const sampleIndices = sampleFrameIndices(rawFrames);
 
       const gifWidth = gif.lsd.width;
       const gifHeight = gif.lsd.height;
@@ -166,23 +226,20 @@ export const extractGifAnimations = async (
         canvasSize,
       );
 
-      // Convert and composite each frame
-      const frames: OffscreenCanvas[] = [];
-      for (const frame of sampledFrames) {
-        const frameCanvas = gifFrameToCanvas(
-          frame,
-          gifWidth,
-          gifHeight,
-          targetW,
-          targetH,
-        );
-        const composited = compositeWithBackground(
-          baseSlideCanvas,
-          frameCanvas,
-          pixelRect,
-        );
-        frames.push(composited);
-      }
+      // Build composed GIF frames with proper inter-frame compositing
+      const composedFrames = buildComposedFrames(
+        rawFrames,
+        sampleIndices,
+        gifWidth,
+        gifHeight,
+        targetW,
+        targetH,
+      );
+
+      // Composite each frame with base slide background (handles transparent GIFs)
+      const frames = composedFrames.map((frameCanvas) =>
+        compositeWithBackground(baseSlideCanvas, frameCanvas, pixelRect),
+      );
 
       animations.push({
         x: pixelRect.x,

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -9,6 +9,7 @@ import { type ParsedFrame, decompressFrames, parseGIF } from "gifuct-js";
 import { emuToPixelRect } from "./emuToPixel";
 
 const MAX_GIF_DIMENSION = 256;
+const MAX_STORED_FRAME_DIMENSION = 512;
 const MAX_FRAMES = 60;
 const TARGET_FPS = 2;
 const TARGET_FRAME_INTERVAL_MS = 1000 / TARGET_FPS;
@@ -20,12 +21,16 @@ const isGif = (buffer: ArrayBuffer): boolean => {
   return sig === "GIF87a" || sig === "GIF89a";
 };
 
-const clampDimensions = (w: number, h: number): { w: number; h: number } => {
+const clampDimensions = (
+  w: number,
+  h: number,
+  maxDimension = MAX_GIF_DIMENSION,
+): { w: number; h: number } => {
   const safeW = Math.max(1, Math.round(w));
   const safeH = Math.max(1, Math.round(h));
-  if (safeW <= MAX_GIF_DIMENSION && safeH <= MAX_GIF_DIMENSION)
+  if (safeW <= maxDimension && safeH <= maxDimension)
     return { w: safeW, h: safeH };
-  const scale = Math.min(MAX_GIF_DIMENSION / safeW, MAX_GIF_DIMENSION / safeH);
+  const scale = Math.min(maxDimension / safeW, maxDimension / safeH);
   return {
     w: Math.max(1, Math.round(safeW * scale)),
     h: Math.max(1, Math.round(safeH * scale)),
@@ -176,8 +181,10 @@ const compositeWithBackground = (
   baseSlideCanvas: OffscreenCanvas,
   gifFrameCanvas: OffscreenCanvas,
   pixelRect: PixelRect,
+  outputW: number,
+  outputH: number,
 ): OffscreenCanvas => {
-  const composited = new OffscreenCanvas(pixelRect.w, pixelRect.h);
+  const composited = new OffscreenCanvas(outputW, outputH);
   const ctx = composited.getContext("2d");
   if (!ctx) throw new Error("Cannot get 2d context");
 
@@ -189,10 +196,10 @@ const compositeWithBackground = (
     pixelRect.h,
     0,
     0,
-    pixelRect.w,
-    pixelRect.h,
+    outputW,
+    outputH,
   );
-  ctx.drawImage(gifFrameCanvas, 0, 0, pixelRect.w, pixelRect.h);
+  ctx.drawImage(gifFrameCanvas, 0, 0, outputW, outputH);
 
   return composited;
 };
@@ -323,6 +330,11 @@ export const extractGifAnimations = async (
       try {
         const sampleIndices = sampleFrameIndices(rawFrames);
         const { w: targetW, h: targetH } = clampDimensions(gifWidth, gifHeight);
+        const { w: storedFrameW, h: storedFrameH } = clampDimensions(
+          pixelRect.w,
+          pixelRect.h,
+          MAX_STORED_FRAME_DIMENSION,
+        );
 
         // Build composed GIF frames with proper inter-frame compositing
         const composedFrames = buildComposedFrames(
@@ -334,7 +346,13 @@ export const extractGifAnimations = async (
           targetH,
         );
         const frames = composedFrames.map((frameCanvas) =>
-          compositeWithBackground(baseSlideCanvas, frameCanvas, pixelRect),
+          compositeWithBackground(
+            baseSlideCanvas,
+            frameCanvas,
+            pixelRect,
+            storedFrameW,
+            storedFrameH,
+          ),
         );
 
         return {

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -21,11 +21,14 @@ const isGif = (buffer: ArrayBuffer): boolean => {
 };
 
 const clampDimensions = (w: number, h: number): { w: number; h: number } => {
-  if (w <= MAX_GIF_DIMENSION && h <= MAX_GIF_DIMENSION) return { w, h };
-  const scale = Math.min(MAX_GIF_DIMENSION / w, MAX_GIF_DIMENSION / h);
+  const safeW = Math.max(1, Math.round(w));
+  const safeH = Math.max(1, Math.round(h));
+  if (safeW <= MAX_GIF_DIMENSION && safeH <= MAX_GIF_DIMENSION)
+    return { w: safeW, h: safeH };
+  const scale = Math.min(MAX_GIF_DIMENSION / safeW, MAX_GIF_DIMENSION / safeH);
   return {
-    w: Math.round(w * scale),
-    h: Math.round(h * scale),
+    w: Math.max(1, Math.round(safeW * scale)),
+    h: Math.max(1, Math.round(safeH * scale)),
   };
 };
 
@@ -110,11 +113,40 @@ const buildComposedFrames = (
     }
 
     // Draw current frame's patch onto the persistent composition canvas
-    const imageData = compositionCtx.createImageData(
+    // while preserving destination pixels under transparent source pixels.
+    const imageData = compositionCtx.getImageData(
+      frame.dims.left,
+      frame.dims.top,
       frame.dims.width,
       frame.dims.height,
     );
-    imageData.data.set(frame.patch);
+    const dstData = imageData.data;
+    const srcData = frame.patch;
+    for (let p = 0; p < srcData.length; p += 4) {
+      const srcA = srcData[p + 3] / 255;
+      if (srcA === 0) continue;
+
+      const dstA = dstData[p + 3] / 255;
+      const outA = srcA + dstA * (1 - srcA);
+      if (outA === 0) {
+        dstData[p] = 0;
+        dstData[p + 1] = 0;
+        dstData[p + 2] = 0;
+        dstData[p + 3] = 0;
+        continue;
+      }
+
+      dstData[p] = Math.round(
+        (srcData[p] * srcA + dstData[p] * dstA * (1 - srcA)) / outA,
+      );
+      dstData[p + 1] = Math.round(
+        (srcData[p + 1] * srcA + dstData[p + 1] * dstA * (1 - srcA)) / outA,
+      );
+      dstData[p + 2] = Math.round(
+        (srcData[p + 2] * srcA + dstData[p + 2] * dstA * (1 - srcA)) / outA,
+      );
+      dstData[p + 3] = Math.round(outA * 255);
+    }
     compositionCtx.putImageData(imageData, frame.dims.left, frame.dims.top);
 
     prevDisposal = disposal;

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -209,7 +209,8 @@ const buildComposedFrames = (
     );
     const dstData = imageData.data;
     const srcData = frame.patch;
-    for (let p = 0; p < srcData.length; p += 4) {
+    const pixelCount = Math.min(srcData.length, dstData.length);
+    for (let p = 0; p < pixelCount; p += 4) {
       const srcA = srcData[p + 3] / 255;
       if (srcA === 0) continue;
 

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -196,87 +196,87 @@ export const extractGifAnimations = async (
       !el.transform.shearY,
   );
 
-  const animations: SelectedFileAnimation[] = [];
+  const results = await Promise.all(
+    imageElements.map(async (element) => {
+      const contentUrl = element.image?.contentUrl;
+      if (!contentUrl) return null;
 
-  for (const element of imageElements) {
-    const contentUrl = element.image?.contentUrl;
-    if (!contentUrl) continue;
+      try {
+        const response = await fetch(contentUrl, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!response.ok) return null;
 
-    try {
-      const response = await fetch(contentUrl, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!response.ok) continue;
+        const buffer = await response.arrayBuffer();
+        if (!isGif(buffer)) return null;
 
-      const buffer = await response.arrayBuffer();
-      if (!isGif(buffer)) continue;
+        const gif = parseGIF(buffer);
+        const rawFrames = decompressFrames(gif, true);
+        if (rawFrames.length <= 1) return null; // Static GIF, skip
 
-      const gif = parseGIF(buffer);
-      const rawFrames = decompressFrames(gif, true);
-      if (rawFrames.length <= 1) continue; // Static GIF, skip
+        const sampleIndices = sampleFrameIndices(rawFrames);
 
-      const sampleIndices = sampleFrameIndices(rawFrames);
+        const gifWidth = gif.lsd.width;
+        const gifHeight = gif.lsd.height;
+        const { w: targetW, h: targetH } = clampDimensions(gifWidth, gifHeight);
 
-      const gifWidth = gif.lsd.width;
-      const gifHeight = gif.lsd.height;
-      const { w: targetW, h: targetH } = clampDimensions(gifWidth, gifHeight);
+        // Compute pixel rect on the rendered slide
+        const sizeW = element.size?.width.magnitude ?? 0;
+        const sizeH = element.size?.height.magnitude ?? 0;
+        const scaleX = element.transform?.scaleX ?? 1;
+        const scaleY = element.transform?.scaleY ?? 1;
+        const translateX = element.transform?.translateX ?? 0;
+        const translateY = element.transform?.translateY ?? 0;
 
-      // Compute pixel rect on the rendered slide
-      const sizeW = element.size?.width.magnitude ?? 0;
-      const sizeH = element.size?.height.magnitude ?? 0;
-      const scaleX = element.transform?.scaleX ?? 1;
-      const scaleY = element.transform?.scaleY ?? 1;
-      const translateX = element.transform?.translateX ?? 0;
-      const translateY = element.transform?.translateY ?? 0;
+        const emuRect = {
+          x: translateX,
+          y: translateY,
+          w: sizeW * scaleX,
+          h: sizeH * scaleY,
+        };
 
-      const emuRect = {
-        x: translateX,
-        y: translateY,
-        w: sizeW * scaleX,
-        h: sizeH * scaleY,
-      };
-
-      const pixelRect = emuToPixelRect(
-        emuRect,
-        { width: pageSize.width, height: pageSize.height },
-        canvasSize,
-      );
-
-      // Build composed GIF frames with proper inter-frame compositing
-      const composedFrames = buildComposedFrames(
-        rawFrames,
-        sampleIndices,
-        gifWidth,
-        gifHeight,
-        targetW,
-        targetH,
-      );
-
-      // Composite each frame with base slide background (handles transparent GIFs)
-      // Close intermediate composed frames after compositing — they are no longer needed
-      const frames = composedFrames.map((frameCanvas) => {
-        const composited = compositeWithBackground(
-          baseSlideCanvas,
-          frameCanvas,
-          pixelRect,
+        const pixelRect = emuToPixelRect(
+          emuRect,
+          { width: pageSize.width, height: pageSize.height },
+          canvasSize,
         );
-        frameCanvas.close();
-        return composited;
-      });
 
-      animations.push({
-        x: pixelRect.x,
-        y: pixelRect.y,
-        w: pixelRect.w,
-        h: pixelRect.h,
-        fps: TARGET_FPS,
-        frames,
-      });
-    } catch (e) {
-      console.warn("Failed to extract GIF animation:", e);
-      // Skip this GIF, continue with others
-    }
-  }
+        // Build composed GIF frames with proper inter-frame compositing
+        const composedFrames = buildComposedFrames(
+          rawFrames,
+          sampleIndices,
+          gifWidth,
+          gifHeight,
+          targetW,
+          targetH,
+        );
 
-  return animations;
+        // Composite each frame with base slide background (handles transparent GIFs)
+        // Close intermediate composed frames after compositing — they are no longer needed
+        const frames = composedFrames.map((frameCanvas) => {
+          const composited = compositeWithBackground(
+            baseSlideCanvas,
+            frameCanvas,
+            pixelRect,
+          );
+          frameCanvas.close();
+          return composited;
+        });
+
+        return {
+          x: pixelRect.x,
+          y: pixelRect.y,
+          w: pixelRect.w,
+          h: pixelRect.h,
+          fps: TARGET_FPS,
+          frames,
+        } satisfies SelectedFileAnimation;
+      } catch (e) {
+        console.warn("Failed to extract GIF animation:", e);
+        return null;
+      }
+    }),
+  );
+
+  return results.filter((r): r is SelectedFileAnimation => r !== null);
 };

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -1,0 +1,202 @@
+import type { SelectedFileAnimation } from "@/_types/file-picker";
+import type { SlidePageElement } from "@/_types/google-slides-api";
+import { type ParsedFrame, decompressFrames, parseGIF } from "gifuct-js";
+import { emuToPixelRect } from "./emuToPixel";
+
+const MAX_GIF_DIMENSION = 256;
+const MAX_FRAMES = 60;
+const TARGET_FPS = 2;
+const TARGET_FRAME_INTERVAL_MS = 1000 / TARGET_FPS;
+
+type PageSize = {
+  width: number;
+  height: number;
+};
+
+type CanvasSize = {
+  width: number;
+  height: number;
+};
+
+const isGif = (buffer: ArrayBuffer): boolean => {
+  const header = new Uint8Array(buffer, 0, 6);
+  const sig = String.fromCharCode(...header);
+  return sig === "GIF87a" || sig === "GIF89a";
+};
+
+const clampDimensions = (w: number, h: number): { w: number; h: number } => {
+  if (w <= MAX_GIF_DIMENSION && h <= MAX_GIF_DIMENSION) return { w, h };
+  const scale = Math.min(MAX_GIF_DIMENSION / w, MAX_GIF_DIMENSION / h);
+  return {
+    w: Math.round(w * scale),
+    h: Math.round(h * scale),
+  };
+};
+
+const sampleFramesAt2Fps = (frames: ParsedFrame[]): ParsedFrame[] => {
+  if (frames.length <= 1) return frames;
+
+  const sampled: ParsedFrame[] = [frames[0]];
+  let accumulatedMs = 0;
+  let nextSampleMs = TARGET_FRAME_INTERVAL_MS;
+
+  for (let i = 1; i < frames.length; i++) {
+    accumulatedMs += frames[i].delay || 100;
+    if (accumulatedMs >= nextSampleMs) {
+      sampled.push(frames[i]);
+      nextSampleMs += TARGET_FRAME_INTERVAL_MS;
+      if (sampled.length >= MAX_FRAMES) break;
+    }
+  }
+  return sampled;
+};
+
+const gifFrameToCanvas = (
+  frame: ParsedFrame,
+  gifWidth: number,
+  gifHeight: number,
+  targetW: number,
+  targetH: number,
+): OffscreenCanvas => {
+  // Draw the decompressed frame patch onto a full-size GIF canvas
+  const fullCanvas = new OffscreenCanvas(gifWidth, gifHeight);
+  const fullCtx = fullCanvas.getContext("2d");
+  if (!fullCtx) throw new Error("Cannot get 2d context");
+
+  const imageData = fullCtx.createImageData(
+    frame.dims.width,
+    frame.dims.height,
+  );
+  imageData.data.set(frame.patch);
+  fullCtx.putImageData(imageData, frame.dims.left, frame.dims.top);
+
+  // Resize to target dimensions
+  if (targetW === gifWidth && targetH === gifHeight) {
+    return fullCanvas;
+  }
+  const resized = new OffscreenCanvas(targetW, targetH);
+  const resizedCtx = resized.getContext("2d");
+  if (!resizedCtx) throw new Error("Cannot get 2d context");
+  resizedCtx.drawImage(fullCanvas, 0, 0, targetW, targetH);
+  return resized;
+};
+
+const compositeWithBackground = (
+  baseSlideCanvas: OffscreenCanvas,
+  gifFrameCanvas: OffscreenCanvas,
+  pixelRect: { x: number; y: number; w: number; h: number },
+): OffscreenCanvas => {
+  const composited = new OffscreenCanvas(pixelRect.w, pixelRect.h);
+  const ctx = composited.getContext("2d");
+  if (!ctx) throw new Error("Cannot get 2d context");
+
+  // Draw base slide region as background
+  ctx.drawImage(
+    baseSlideCanvas,
+    pixelRect.x,
+    pixelRect.y,
+    pixelRect.w,
+    pixelRect.h,
+    0,
+    0,
+    pixelRect.w,
+    pixelRect.h,
+  );
+
+  // Overlay GIF frame (transparent areas will show base)
+  ctx.drawImage(gifFrameCanvas, 0, 0, pixelRect.w, pixelRect.h);
+
+  return composited;
+};
+
+export const extractGifAnimations = async (
+  pageElements: SlidePageElement[],
+  pageSize: PageSize,
+  canvasSize: CanvasSize,
+  baseSlideCanvas: OffscreenCanvas,
+  token: string,
+): Promise<SelectedFileAnimation[]> => {
+  const imageElements = pageElements.filter(
+    (el) => el.image?.contentUrl && el.size && el.transform,
+  );
+
+  const animations: SelectedFileAnimation[] = [];
+
+  for (const element of imageElements) {
+    const contentUrl = element.image?.contentUrl;
+    if (!contentUrl) continue;
+
+    try {
+      const response = await fetch(contentUrl, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!response.ok) continue;
+
+      const buffer = await response.arrayBuffer();
+      if (!isGif(buffer)) continue;
+
+      const gif = parseGIF(buffer);
+      const rawFrames = decompressFrames(gif, true);
+      if (rawFrames.length <= 1) continue; // Static GIF, skip
+
+      const sampledFrames = sampleFramesAt2Fps(rawFrames);
+
+      const gifWidth = gif.lsd.width;
+      const gifHeight = gif.lsd.height;
+      const { w: targetW, h: targetH } = clampDimensions(gifWidth, gifHeight);
+
+      // Compute pixel rect on the rendered slide
+      const sizeW = element.size?.width.magnitude ?? 0;
+      const sizeH = element.size?.height.magnitude ?? 0;
+      const scaleX = element.transform?.scaleX ?? 1;
+      const scaleY = element.transform?.scaleY ?? 1;
+      const translateX = element.transform?.translateX ?? 0;
+      const translateY = element.transform?.translateY ?? 0;
+
+      const emuRect = {
+        x: translateX,
+        y: translateY,
+        w: sizeW * scaleX,
+        h: sizeH * scaleY,
+      };
+
+      const pixelRect = emuToPixelRect(
+        emuRect,
+        { width: pageSize.width, height: pageSize.height },
+        canvasSize,
+      );
+
+      // Convert and composite each frame
+      const frames: OffscreenCanvas[] = [];
+      for (const frame of sampledFrames) {
+        const frameCanvas = gifFrameToCanvas(
+          frame,
+          gifWidth,
+          gifHeight,
+          targetW,
+          targetH,
+        );
+        const composited = compositeWithBackground(
+          baseSlideCanvas,
+          frameCanvas,
+          pixelRect,
+        );
+        frames.push(composited);
+      }
+
+      animations.push({
+        x: pixelRect.x,
+        y: pixelRect.y,
+        w: pixelRect.w,
+        h: pixelRect.h,
+        fps: TARGET_FPS,
+        frames,
+      });
+    } catch (e) {
+      console.warn("Failed to extract GIF animation:", e);
+      // Skip this GIF, continue with others
+    }
+  }
+
+  return animations;
+};

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -37,6 +37,40 @@ const clampDimensions = (
   };
 };
 
+const toPixelRect = (
+  element: SlidePageElement,
+  pageSize: PageSize,
+  canvasSize: CanvasSize,
+): PixelRect | null => {
+  const size = element.size;
+  const transform = element.transform;
+  const scaleX = transform?.scaleX;
+  const scaleY = transform?.scaleY;
+  if (
+    !size ||
+    !transform ||
+    // Only positive scale without shear is supported for pixel-rect projection.
+    !!transform.shearX ||
+    !!transform.shearY ||
+    typeof scaleX !== "number" ||
+    scaleX <= 0 ||
+    typeof scaleY !== "number" ||
+    scaleY <= 0
+  ) {
+    return null;
+  }
+
+  const emuRect = {
+    x: transform.translateX ?? 0,
+    y: transform.translateY ?? 0,
+    w: size.width.magnitude * scaleX,
+    h: size.height.magnitude * scaleY,
+  };
+  const pixelRect = emuToPixelRect(emuRect, pageSize, canvasSize);
+  if (pixelRect.w <= 0 || pixelRect.h <= 0) return null;
+  return pixelRect;
+};
+
 /**
  * Returns an ordered array of frame indices to output at TARGET_FPS.
  * A single source frame may appear multiple times if its delay spans
@@ -219,33 +253,9 @@ export const extractGifAnimations = async (
   const imageElements = pageElements
     .map((element) => {
       const contentUrl = element.image?.contentUrl;
-      const size = element.size;
-      const transform = element.transform;
-      const scaleX = transform?.scaleX;
-      const scaleY = transform?.scaleY;
-      if (
-        !contentUrl ||
-        !size ||
-        !transform ||
-        // Skip rotated/sheared/flipped elements — only positive scale without shear is supported
-        !!transform.shearX ||
-        !!transform.shearY ||
-        typeof scaleX !== "number" ||
-        scaleX <= 0 ||
-        typeof scaleY !== "number" ||
-        scaleY <= 0
-      ) {
-        return null;
-      }
-
-      const emuRect = {
-        x: transform.translateX ?? 0,
-        y: transform.translateY ?? 0,
-        w: size.width.magnitude * scaleX,
-        h: size.height.magnitude * scaleY,
-      };
-      const pixelRect = emuToPixelRect(emuRect, pageSize, canvasSize);
-      if (pixelRect.w <= 0 || pixelRect.h <= 0) return null;
+      if (!contentUrl) return null;
+      const pixelRect = toPixelRect(element, pageSize, canvasSize);
+      if (!pixelRect) return null;
 
       return { element, pixelRect };
     })
@@ -258,45 +268,72 @@ export const extractGifAnimations = async (
       } => el !== null,
     );
 
+  const positionedElements = pageElements
+    .map((element) => {
+      const pixelRect = toPixelRect(element, pageSize, canvasSize);
+      if (!pixelRect) return null;
+      return { element, pixelRect };
+    })
+    .filter(
+      (
+        el,
+      ): el is {
+        element: SlidePageElement;
+        pixelRect: PixelRect;
+      } => el !== null,
+    );
+
   type AnimatedGifCandidate = {
+    element: SlidePageElement;
     pixelRect: PixelRect;
     rawFrames: ParsedFrame[];
     gifWidth: number;
     gifHeight: number;
   };
 
-  const animatedGifCandidates = (
-    await Promise.all(
-      imageElements.map(async ({ element, pixelRect }) => {
-        const contentUrl = element.image?.contentUrl;
-        if (!contentUrl) return null;
+  const animatedGifCandidatesRaw: (AnimatedGifCandidate | null)[] = [];
+  for (const { element, pixelRect } of imageElements) {
+    const contentUrl = element.image?.contentUrl;
+    if (!contentUrl) {
+      animatedGifCandidatesRaw.push(null);
+      continue;
+    }
+    try {
+      const response = await fetch(contentUrl, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!response.ok) {
+        animatedGifCandidatesRaw.push(null);
+        continue;
+      }
 
-        try {
-          const response = await fetch(contentUrl, {
-            headers: { Authorization: `Bearer ${token}` },
-          });
-          if (!response.ok) return null;
+      const buffer = await response.arrayBuffer();
+      if (!isGif(buffer)) {
+        animatedGifCandidatesRaw.push(null);
+        continue;
+      }
 
-          const buffer = await response.arrayBuffer();
-          if (!isGif(buffer)) return null;
+      const gif = parseGIF(buffer);
+      const rawFrames = decompressFrames(gif, true);
+      if (rawFrames.length <= 1) {
+        animatedGifCandidatesRaw.push(null); // Static GIF, skip
+        continue;
+      }
 
-          const gif = parseGIF(buffer);
-          const rawFrames = decompressFrames(gif, true);
-          if (rawFrames.length <= 1) return null; // Static GIF, skip
+      animatedGifCandidatesRaw.push({
+        element,
+        pixelRect,
+        rawFrames,
+        gifWidth: gif.lsd.width,
+        gifHeight: gif.lsd.height,
+      } satisfies AnimatedGifCandidate);
+    } catch (e) {
+      console.warn("Failed to extract GIF animation:", e);
+      animatedGifCandidatesRaw.push(null);
+    }
+  }
 
-          return {
-            pixelRect,
-            rawFrames,
-            gifWidth: gif.lsd.width,
-            gifHeight: gif.lsd.height,
-          } satisfies AnimatedGifCandidate;
-        } catch (e) {
-          console.warn("Failed to extract GIF animation:", e);
-          return null;
-        }
-      }),
-    )
-  ).filter(
+  const animatedGifCandidates = animatedGifCandidatesRaw.filter(
     (candidate): candidate is AnimatedGifCandidate => candidate !== null,
   );
 
@@ -321,8 +358,30 @@ export const extractGifAnimations = async (
     );
   }
 
+  const animatedElements = new Set(animatedGifCandidates.map((c) => c.element));
+  const intersectingNonAnimatedIndices = new Set<number>();
+  for (let i = 0; i < animatedGifCandidates.length; i++) {
+    const candidate = animatedGifCandidates[i];
+    for (const positioned of positionedElements) {
+      if (positioned.element === candidate.element) continue;
+      if (animatedElements.has(positioned.element)) continue;
+      if (rectsIntersect(candidate.pixelRect, positioned.pixelRect)) {
+        intersectingNonAnimatedIndices.add(i);
+        break;
+      }
+    }
+  }
+
+  if (intersectingNonAnimatedIndices.size > 0) {
+    console.warn(
+      `extractGifAnimations: skipping ${intersectingNonAnimatedIndices.size} animated GIF element(s) overlapping non-animated elements; preserving foreground overlap is not supported with RGB24 animation encoding`,
+    );
+  }
+
   const nonIntersectingAnimatedCandidates = animatedGifCandidates.filter(
-    (_, index) => !intersectingElementIndices.has(index),
+    (_, index) =>
+      !intersectingElementIndices.has(index) &&
+      !intersectingNonAnimatedIndices.has(index),
   );
 
   const results = nonIntersectingAnimatedCandidates

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -71,6 +71,52 @@ const toPixelRect = (
   return pixelRect;
 };
 
+const computeAABBFromTransformedCorners = (
+  element: SlidePageElement,
+  pageSize: PageSize,
+  canvasSize: CanvasSize,
+): PixelRect | null => {
+  const size = element.size;
+  const transform = element.transform;
+  if (!size || !transform) return null;
+  const sourceW = size.width.magnitude;
+  const sourceH = size.height.magnitude;
+  if (sourceW <= 0 || sourceH <= 0) return null;
+
+  const scaleX = transform.scaleX ?? 1;
+  const scaleY = transform.scaleY ?? 1;
+  const shearX = transform.shearX ?? 0;
+  const shearY = transform.shearY ?? 0;
+  const translateX = transform.translateX ?? 0;
+  const translateY = transform.translateY ?? 0;
+
+  const corners = [
+    { x: 0, y: 0 },
+    { x: sourceW, y: 0 },
+    { x: 0, y: sourceH },
+    { x: sourceW, y: sourceH },
+  ];
+  const pixelScaleX = canvasSize.width / pageSize.width;
+  const pixelScaleY = canvasSize.height / pageSize.height;
+
+  const transformedCorners = corners.map(({ x, y }) => {
+    const emuX = scaleX * x + shearX * y + translateX;
+    const emuY = shearY * x + scaleY * y + translateY;
+    return { x: emuX * pixelScaleX, y: emuY * pixelScaleY };
+  });
+
+  const minX = Math.min(...transformedCorners.map((p) => p.x));
+  const maxX = Math.max(...transformedCorners.map((p) => p.x));
+  const minY = Math.min(...transformedCorners.map((p) => p.y));
+  const maxY = Math.max(...transformedCorners.map((p) => p.y));
+
+  const x = Math.floor(minX);
+  const y = Math.floor(minY);
+  const w = Math.max(1, Math.ceil(maxX) - x);
+  const h = Math.max(1, Math.ceil(maxY) - y);
+  return { x, y, w, h };
+};
+
 /**
  * Returns an ordered array of frame indices to output at TARGET_FPS.
  * A single source frame may appear multiple times if its delay spans
@@ -167,13 +213,6 @@ const buildComposedFrames = (
 
       const dstA = dstData[p + 3] / 255;
       const outA = srcA + dstA * (1 - srcA);
-      if (outA === 0) {
-        dstData[p] = 0;
-        dstData[p + 1] = 0;
-        dstData[p + 2] = 0;
-        dstData[p + 3] = 0;
-        continue;
-      }
 
       dstData[p] = Math.round(
         (srcData[p] * srcA + dstData[p] * dstA * (1 - srcA)) / outA,
@@ -210,6 +249,17 @@ const buildComposedFrames = (
 
 const rectsIntersect = (a: PixelRect, b: PixelRect): boolean =>
   a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+
+const hasTransparency = (canvas: OffscreenCanvas): boolean => {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Cannot get 2d context");
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const data = imageData.data;
+  for (let i = 3; i < data.length; i += 4) {
+    if (data[i] < 255) return true;
+  }
+  return false;
+};
 
 const compositeWithBackground = (
   baseSlideCanvas: OffscreenCanvas,
@@ -270,7 +320,9 @@ export const extractGifAnimations = async (
 
   const positionedElements = pageElements
     .map((element) => {
-      const pixelRect = toPixelRect(element, pageSize, canvasSize);
+      const pixelRect =
+        toPixelRect(element, pageSize, canvasSize) ??
+        computeAABBFromTransformedCorners(element, pageSize, canvasSize);
       if (!pixelRect) return null;
       return { element, pixelRect };
     })
@@ -299,18 +351,33 @@ export const extractGifAnimations = async (
       continue;
     }
     try {
-      const response = await fetch(contentUrl, {
-        headers: { Authorization: `Bearer ${token}` },
+      const rangeSniffResponse = await fetch(contentUrl, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Range: "bytes=0-5",
+        },
       });
-      if (!response.ok) {
+      if (!rangeSniffResponse.ok) {
         animatedGifCandidatesRaw.push(null);
         continue;
       }
 
-      const buffer = await response.arrayBuffer();
-      if (!isGif(buffer)) {
+      const headerBuffer = await rangeSniffResponse.arrayBuffer();
+      if (!isGif(headerBuffer)) {
         animatedGifCandidatesRaw.push(null);
         continue;
+      }
+
+      let buffer = headerBuffer;
+      if (rangeSniffResponse.status === 206 || headerBuffer.byteLength <= 6) {
+        const fullResponse = await fetch(contentUrl, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!fullResponse.ok) {
+          animatedGifCandidatesRaw.push(null);
+          continue;
+        }
+        buffer = await fullResponse.arrayBuffer();
       }
 
       const gif = parseGIF(buffer);
@@ -404,6 +471,14 @@ export const extractGifAnimations = async (
           targetW,
           targetH,
         );
+        if (
+          composedFrames.some((frameCanvas) => hasTransparency(frameCanvas))
+        ) {
+          console.warn(
+            "extractGifAnimations: skipping animated GIF element with transparent pixels; transparency is not supported with RGB24 animation encoding",
+          );
+          return null;
+        }
         const frames = composedFrames.map((frameCanvas) =>
           compositeWithBackground(
             baseSlideCanvas,

--- a/src/lib/google/fetchSlideMetadatas.ts
+++ b/src/lib/google/fetchSlideMetadatas.ts
@@ -1,13 +1,18 @@
-import type { GetSlideResponse } from "@/_types/google-slides-api";
+import type {
+  GetSlideResponse,
+  SlidePageElement,
+} from "@/_types/google-slides-api";
 
 type SlideMetadata = {
   title: string;
   items: SlideItem[];
+  pageSize: { width: number; height: number };
 };
 
 type SlideItem = {
   speakerNote: string;
   isSkipped: boolean;
+  pageElements: SlidePageElement[];
 };
 
 export const fetchSlideMetadata = async (
@@ -33,10 +38,15 @@ export const fetchSlideMetadata = async (
     return {
       speakerNote,
       isSkipped: slide.slideProperties.isSkipped || false,
+      pageElements: slide.pageElements ?? [],
     };
   });
   return {
     title: response.result.title,
     items,
+    pageSize: {
+      width: response.result.pageSize.width.magnitude,
+      height: response.result.pageSize.height.magnitude,
+    },
   };
 };

--- a/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
+++ b/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
@@ -46,7 +46,7 @@ export const selectedFiles2EIAv1RGB24Cropped = async (
       }));
       // Apply differential compression to animation frames
       const croppedAnimFrames = cropImages(animRawImages, {
-        keyframeInterval: 10,
+        keyframeInterval,
         parentSearchWindow: 5,
         parentSearchTopK: 1,
       });

--- a/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
+++ b/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
@@ -1,9 +1,10 @@
+import type { RawAnimationData } from "@/_types/eia/rawAnimationData";
 import type { EIASignageManifest } from "@/_types/eia/v1";
 import type { SelectedFile } from "@/_types/file-picker";
 import type { RawImageObjV1 } from "@/_types/text-zip/v1";
+import { IMAGE_FORMAT_RGB24 } from "@/const/imageFormat";
 import { canvas2rgb24 } from "@/lib/canvas2rawImage/canvas2rgb24";
 import { compressEIAv1 } from "@/lib/eia/compressEIAv1";
-import type { RawAnimationData } from "@/lib/eia/compressEIAv1";
 import { cropImages } from "../crop/cropImages";
 
 const keyframeInterval = 10;
@@ -18,7 +19,7 @@ export const selectedFiles2EIAv1RGB24Cropped = async (
       width: file.canvas.width,
       height: file.canvas.height,
     },
-    format: "RGB24",
+    format: IMAGE_FORMAT_RGB24,
     note: file.note,
     buffer: Buffer.from(canvas2rgb24(file.canvas)),
   }));
@@ -41,7 +42,7 @@ export const selectedFiles2EIAv1RGB24Cropped = async (
       const animRawImages = anim.frames.map<RawImageObjV1>((frame, fi) => ({
         index: fi,
         rect: { width: frame.width, height: frame.height },
-        format: "RGB24",
+        format: IMAGE_FORMAT_RGB24,
         buffer: Buffer.from(canvas2rgb24(frame)),
       }));
       // Apply differential compression to animation frames
@@ -56,7 +57,7 @@ export const selectedFiles2EIAv1RGB24Cropped = async (
         w: anim.w,
         h: anim.h,
         fps: anim.fps,
-        format: "RGB24",
+        format: IMAGE_FORMAT_RGB24,
         frames: croppedAnimFrames,
       };
     });

--- a/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
+++ b/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
@@ -56,6 +56,7 @@ export const selectedFiles2EIAv1RGB24Cropped = async (
         w: anim.w,
         h: anim.h,
         fps: anim.fps,
+        format: "RGB24",
         frames: croppedAnimFrames,
       };
     });

--- a/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
+++ b/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
@@ -43,8 +43,6 @@ export const selectedFiles2EIAv1RGB24Cropped = async (
       h: anim.h,
       fps: anim.fps,
       frames: anim.frames.map((frame) => ({
-        width: frame.width,
-        height: frame.height,
         buffer: Buffer.from(canvas2rgb24(frame)),
       })),
     }));

--- a/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
+++ b/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
@@ -3,6 +3,7 @@ import type { SelectedFile } from "@/_types/file-picker";
 import type { RawImageObjV1 } from "@/_types/text-zip/v1";
 import { canvas2rgb24 } from "@/lib/canvas2rawImage/canvas2rgb24";
 import { compressEIAv1 } from "@/lib/eia/compressEIAv1";
+import type { RawAnimationData } from "@/lib/eia/compressEIAv1";
 import { cropImages } from "../crop/cropImages";
 
 const keyframeInterval = 10;
@@ -30,5 +31,31 @@ export const selectedFiles2EIAv1RGB24Cropped = async (
     `after compress size: ${croppedImages.reduce((acc, cur) => acc + (cur.cropped ? cur.cropped.rects.reduce((acc, cur) => acc + cur.buffer.length, 0) : cur.buffer.length), 0)}`,
   );
 
-  return await compressEIAv1(croppedImages, signage, 1, keyframeInterval);
+  // Extract animation data per slide
+  const animationMap = new Map<number, RawAnimationData[]>();
+  for (let i = 0; i < selectedFiles.length; i++) {
+    const file = selectedFiles[i];
+    if (!file.animations || file.animations.length === 0) continue;
+    const anims: RawAnimationData[] = file.animations.map((anim) => ({
+      x: anim.x,
+      y: anim.y,
+      w: anim.w,
+      h: anim.h,
+      fps: anim.fps,
+      frames: anim.frames.map((frame) => ({
+        width: frame.width,
+        height: frame.height,
+        buffer: Buffer.from(canvas2rgb24(frame)),
+      })),
+    }));
+    animationMap.set(i, anims);
+  }
+
+  return await compressEIAv1(
+    croppedImages,
+    signage,
+    1,
+    keyframeInterval,
+    animationMap.size > 0 ? animationMap : undefined,
+  );
 };

--- a/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
+++ b/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
@@ -32,36 +32,42 @@ export const selectedFiles2EIAv1RGB24Cropped = async (
     `after compress size: ${croppedImages.reduce((acc, cur) => acc + (cur.cropped ? cur.cropped.rects.reduce((acc, cur) => acc + cur.buffer.length, 0) : cur.buffer.length), 0)}`,
   );
 
-  // Extract animation data per slide
-  const animationMap = new Map<number, RawAnimationData[]>();
-  for (let i = 0; i < selectedFiles.length; i++) {
-    const file = selectedFiles[i];
-    if (!file.animations || file.animations.length === 0) continue;
-    const anims: RawAnimationData[] = file.animations.map((anim) => {
-      // Convert animation frames to RawImageObjV1 for cropImages
-      const animRawImages = anim.frames.map<RawImageObjV1>((frame, fi) => ({
-        index: fi,
-        rect: { width: frame.width, height: frame.height },
-        format: IMAGE_FORMAT_RGB24,
-        buffer: Buffer.from(canvas2rgb24(frame)),
-      }));
-      // Apply differential compression to animation frames
-      const croppedAnimFrames = cropImages(animRawImages, {
-        keyframeInterval,
-        parentSearchWindow: 5,
-        parentSearchTopK: 1,
+  let animationMap: Map<number, RawAnimationData[]> | undefined;
+  if (!signage) {
+    // Extract animation data per slide (signage exports intentionally omit animations)
+    const extractedAnimationMap = new Map<number, RawAnimationData[]>();
+    for (let i = 0; i < selectedFiles.length; i++) {
+      const file = selectedFiles[i];
+      if (!file.animations || file.animations.length === 0) continue;
+      const anims: RawAnimationData[] = file.animations.map((anim) => {
+        // Convert animation frames to RawImageObjV1 for cropImages
+        const animRawImages = anim.frames.map<RawImageObjV1>((frame, fi) => ({
+          index: fi,
+          rect: { width: frame.width, height: frame.height },
+          format: IMAGE_FORMAT_RGB24,
+          buffer: Buffer.from(canvas2rgb24(frame)),
+        }));
+        // Apply differential compression to animation frames
+        const croppedAnimFrames = cropImages(animRawImages, {
+          keyframeInterval,
+          parentSearchWindow: 5,
+          parentSearchTopK: 1,
+        });
+        return {
+          x: anim.x,
+          y: anim.y,
+          w: anim.w,
+          h: anim.h,
+          fps: anim.fps,
+          format: IMAGE_FORMAT_RGB24,
+          frames: croppedAnimFrames,
+        };
       });
-      return {
-        x: anim.x,
-        y: anim.y,
-        w: anim.w,
-        h: anim.h,
-        fps: anim.fps,
-        format: IMAGE_FORMAT_RGB24,
-        frames: croppedAnimFrames,
-      };
-    });
-    animationMap.set(i, anims);
+      extractedAnimationMap.set(i, anims);
+    }
+    if (extractedAnimationMap.size > 0) {
+      animationMap = extractedAnimationMap;
+    }
   }
 
   return await compressEIAv1(
@@ -69,6 +75,6 @@ export const selectedFiles2EIAv1RGB24Cropped = async (
     signage,
     1,
     keyframeInterval,
-    animationMap.size > 0 ? animationMap : undefined,
+    animationMap,
   );
 };

--- a/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
+++ b/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
@@ -36,16 +36,29 @@ export const selectedFiles2EIAv1RGB24Cropped = async (
   for (let i = 0; i < selectedFiles.length; i++) {
     const file = selectedFiles[i];
     if (!file.animations || file.animations.length === 0) continue;
-    const anims: RawAnimationData[] = file.animations.map((anim) => ({
-      x: anim.x,
-      y: anim.y,
-      w: anim.w,
-      h: anim.h,
-      fps: anim.fps,
-      frames: anim.frames.map((frame) => ({
+    const anims: RawAnimationData[] = file.animations.map((anim) => {
+      // Convert animation frames to RawImageObjV1 for cropImages
+      const animRawImages = anim.frames.map<RawImageObjV1>((frame, fi) => ({
+        index: fi,
+        rect: { width: frame.width, height: frame.height },
+        format: "RGB24",
         buffer: Buffer.from(canvas2rgb24(frame)),
-      })),
-    }));
+      }));
+      // Apply differential compression to animation frames
+      const croppedAnimFrames = cropImages(animRawImages, {
+        keyframeInterval: 10,
+        parentSearchWindow: 5,
+        parentSearchTopK: 1,
+      });
+      return {
+        x: anim.x,
+        y: anim.y,
+        w: anim.w,
+        h: anim.h,
+        fps: anim.fps,
+        frames: croppedAnimFrames,
+      };
+    });
     animationMap.set(i, anims);
   }
 

--- a/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24CroppedBase64.ts
+++ b/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24CroppedBase64.ts
@@ -11,6 +11,15 @@ export const selectedFiles2EIAv1RGB24CroppedBase64 = async (
   selectedFiles: SelectedFile[],
   signage?: EIASignageManifest,
 ): Promise<Buffer[]> => {
+  const hasAnimations = selectedFiles.some(
+    (file) => !!file.animations && file.animations.length > 0,
+  );
+  if (hasAnimations) {
+    throw new Error(
+      "EIA v1 RGB24 cropped base64 does not support animations. Use eia-v1-RGB24-cropped.",
+    );
+  }
+
   const rawImages = selectedFiles.map<RawImageObjV1>((file, index) => ({
     index,
     rect: {

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -1,6 +1,8 @@
 import type {
+  EIAAnimationFrameRefCropped,
   EIAAnimationMeta,
   EIAFileV1Cropped,
+  EIAFileV1CroppedPart,
   EIAManifestV1,
 } from "@/_types/eia/v1";
 import type { SlideAnimation, SlideFrame } from "@/_types/slide-preview";
@@ -43,20 +45,21 @@ const rawToImageData = (
 const applyRects = (
   baseBuffer: Uint8Array,
   decompressed: Uint8Array,
-  item: EIAFileV1Cropped,
+  rects: EIAFileV1CroppedPart[],
   baseWidth: number,
+  format: string,
 ): Uint8Array => {
   const bpp =
-    item.f === "RGBA32"
+    format === "RGBA32"
       ? 4
-      : isRgb24(item.f)
+      : isRgb24(format)
         ? 3
         : (() => {
-            throw new Error(`Unsupported format in applyRects: "${item.f}"`);
+            throw new Error(`Unsupported format in applyRects: "${format}"`);
           })();
   const result = new Uint8Array(baseBuffer);
   const baseHeight = baseBuffer.length / (baseWidth * bpp);
-  for (const rect of item.r) {
+  for (const rect of rects) {
     if (rect.x + rect.w > baseWidth || rect.y + rect.h > baseHeight)
       throw new Error(
         `Rect at (${rect.x},${rect.y}) size ${rect.w}×${rect.h} exceeds frame bounds ${baseWidth}×${baseHeight}`,
@@ -148,7 +151,13 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): SlideFrame[] => {
           `Cropped frame "${item.n}" format "${item.f}" ` +
             `differs from base "${item.b}" format "${baseItem.f}"`,
         );
-      rawBuffer = applyRects(baseBuffer, decompressed, item, baseItem.w);
+      rawBuffer = applyRects(
+        baseBuffer,
+        decompressed,
+        item.r,
+        baseItem.w,
+        item.f,
+      );
     }
 
     frameBuffers.set(item.n, rawBuffer);
@@ -164,7 +173,18 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): SlideFrame[] => {
         const animMetas: EIAAnimationMeta[] = JSON.parse(item.e.a);
         animations = animMetas.map((meta) => {
           const animFrames: ImageData[] = [];
-          for (const frameRef of meta.frames) {
+          const animFrameBuffers = new Map<number, Uint8Array>();
+
+          // Pre-scan to find which frames are referenced as base by cropped frames
+          const animBaseIndices = new Set<number>();
+          for (const fr of meta.frames) {
+            if ("t" in fr && fr.t === "c") {
+              animBaseIndices.add((fr as EIAAnimationFrameRefCropped).b);
+            }
+          }
+
+          for (let fi = 0; fi < meta.frames.length; fi++) {
+            const frameRef = meta.frames[fi];
             if (frameRef.s + frameRef.l > binarySection.length) {
               throw new Error(
                 `Animation frame ref out of bounds: offset ${frameRef.s} + length ${frameRef.l} ` +
@@ -178,11 +198,38 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): SlideFrame[] => {
             const decompressedFrame = lz4Decompress(
               compressedFrame,
               frameRef.u,
-              `anim_${item.n}`,
+              `anim_${item.n}_${fi}`,
             );
-            animFrames.push(
-              rawToImageData(decompressedFrame, meta.w, meta.h, meta.f),
-            );
+
+            let rawBuffer: Uint8Array;
+            if (!("t" in frameRef) || frameRef.t === "m") {
+              // Master frame (or legacy frame without 't' field)
+              rawBuffer = decompressedFrame;
+            } else {
+              // Cropped frame: apply rects to base
+              const croppedRef = frameRef as EIAAnimationFrameRefCropped;
+              const baseBuffer = animFrameBuffers.get(croppedRef.b);
+              if (!baseBuffer) {
+                throw new Error(
+                  `Animation base frame ${croppedRef.b} not found for cropped frame ${fi}`,
+                );
+              }
+              rawBuffer = applyRects(
+                baseBuffer,
+                decompressedFrame,
+                croppedRef.r,
+                meta.w,
+                meta.f,
+              );
+            }
+
+            animFrameBuffers.set(fi, rawBuffer);
+            animFrames.push(rawToImageData(rawBuffer, meta.w, meta.h, meta.f));
+
+            // Release buffer if not needed as base for future frames
+            if (!animBaseIndices.has(fi)) {
+              animFrameBuffers.delete(fi);
+            }
           }
           return {
             x: meta.x,

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -96,7 +96,7 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): SlideFrame[] => {
   const manifest: EIAManifestV1 = JSON.parse(
     textDecoder.decode(uint8.subarray(4, dollarPos)),
   );
-  if (manifest.v !== 1)
+  if (manifest.v !== 1 && manifest.v !== 2)
     throw new Error(`Unsupported EIA version: ${manifest.v}`);
   if (manifest.c !== "lz4" && manifest.c !== "lz4-base64")
     throw new Error(`Unsupported compression: ${manifest.c}`);
@@ -191,6 +191,8 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): SlideFrame[] => {
         const decodedAnimations = animMetas
           .map((meta, metaIndex): SlideAnimation | null => {
             try {
+              const frameWidth = meta.fw ?? meta.w;
+              const frameHeight = meta.fh ?? meta.h;
               const animFrames: ImageData[] = [];
               const animFrameBuffers = new Map<number, Uint8Array>();
 
@@ -237,14 +239,14 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): SlideFrame[] => {
                     baseBuffer,
                     decompressedFrame,
                     croppedRef.r,
-                    meta.w,
+                    frameWidth,
                     meta.f,
                   );
                 }
 
                 animFrameBuffers.set(fi, rawBuffer);
                 animFrames.push(
-                  rawToImageData(rawBuffer, meta.w, meta.h, meta.f),
+                  rawToImageData(rawBuffer, frameWidth, frameHeight, meta.f),
                 );
 
                 // Release buffer if not needed as base for future frames

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -165,6 +165,12 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): SlideFrame[] => {
         animations = animMetas.map((meta) => {
           const animFrames: ImageData[] = [];
           for (const frameRef of meta.frames) {
+            if (frameRef.s + frameRef.l > binarySection.length) {
+              throw new Error(
+                `Animation frame ref out of bounds: offset ${frameRef.s} + length ${frameRef.l} ` +
+                  `exceeds binary section size ${binarySection.length}`,
+              );
+            }
             const compressedFrame = binarySection.subarray(
               frameRef.s,
               frameRef.s + frameRef.l,

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -1,5 +1,9 @@
-import type { EIAFileV1Cropped, EIAManifestV1 } from "@/_types/eia/v1";
-import type { SlideFrame } from "@/_types/slide-preview";
+import type {
+  EIAAnimationMeta,
+  EIAFileV1Cropped,
+  EIAManifestV1,
+} from "@/_types/eia/v1";
+import type { SlideAnimation, SlideFrame } from "@/_types/slide-preview";
 import lz4 from "lz4js";
 import { rgb24ToImageData, rgba32ToImageData } from "./rawImage2ImageData";
 
@@ -153,11 +157,63 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): SlideFrame[] => {
     if (!Number.isFinite(index))
       throw new Error(`Non-numeric frame name: "${item.n}"`);
 
+    // Decode animation data from e.a extension
+    let animations: SlideAnimation[] | undefined;
+    if (item.e?.a) {
+      try {
+        const animMetas: EIAAnimationMeta[] = JSON.parse(item.e.a);
+        animations = animMetas.map((meta) => {
+          const animFrames: ImageData[] = [];
+          for (const frameRef of meta.frames) {
+            let decompressedFrame: Uint8Array;
+            if (binarySection !== null) {
+              const compressedFrame = binarySection.subarray(
+                frameRef.s,
+                frameRef.s + frameRef.l,
+              );
+              decompressedFrame = lz4Decompress(
+                compressedFrame,
+                frameRef.u,
+                `anim_${item.n}`,
+              );
+            } else if (textSection !== null) {
+              const b64Frame = textSection.substring(
+                frameRef.s,
+                frameRef.s + frameRef.l,
+              );
+              const compressedFrame = base64ToUint8Array(b64Frame);
+              decompressedFrame = lz4Decompress(
+                compressedFrame,
+                frameRef.u,
+                `anim_${item.n}`,
+              );
+            } else {
+              throw new Error(`Unsupported compression: ${manifest.c}`);
+            }
+            animFrames.push(
+              rawToImageData(decompressedFrame, meta.w, meta.h, meta.f),
+            );
+          }
+          return {
+            x: meta.x,
+            y: meta.y,
+            w: meta.w,
+            h: meta.h,
+            fps: meta.fps,
+            frames: animFrames,
+          };
+        });
+      } catch (e) {
+        console.warn(`Failed to decode animation for frame "${item.n}":`, e);
+      }
+    }
+
     frames.push({
       index,
       width: item.w,
       height: item.h,
       imageData: rawToImageData(rawBuffer, item.w, item.h, item.f),
+      animations,
     });
 
     // Release raw buffer if no later frame references it as a base

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -168,85 +168,88 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): SlideFrame[] => {
 
     // Decode animation data from e.a extension (binary lz4 only)
     let animations: SlideAnimation[] | undefined;
-    if (item.e?.a && binarySection === null) {
-      console.warn(
-        `Animation data for frame "${item.n}" cannot be decoded under lz4-base64 compression`,
-      );
-    }
-    if (item.e?.a && binarySection !== null) {
-      try {
-        const animMetas: EIAAnimationMeta[] = JSON.parse(item.e.a);
-        animations = animMetas.map((meta) => {
-          const animFrames: ImageData[] = [];
-          const animFrameBuffers = new Map<number, Uint8Array>();
+    if (item.e?.a) {
+      if (binarySection === null) {
+        console.warn(
+          `Animation data for frame "${item.n}" cannot be decoded under lz4-base64 compression`,
+        );
+      } else {
+        try {
+          const animMetas: EIAAnimationMeta[] = JSON.parse(item.e.a);
+          animations = animMetas.map((meta) => {
+            const animFrames: ImageData[] = [];
+            const animFrameBuffers = new Map<number, Uint8Array>();
 
-          // Pre-scan to find which frames are referenced as base by cropped frames
-          const animBaseIndices = new Set<number>();
-          for (const fr of meta.frames) {
-            if ("t" in fr && fr.t === "c") {
-              animBaseIndices.add((fr as EIAAnimationFrameRefCropped).b);
+            // Pre-scan to find which frames are referenced as base by cropped frames
+            const animBaseIndices = new Set<number>();
+            for (const fr of meta.frames) {
+              if ("t" in fr && fr.t === "c") {
+                animBaseIndices.add((fr as EIAAnimationFrameRefCropped).b);
+              }
             }
-          }
 
-          for (let fi = 0; fi < meta.frames.length; fi++) {
-            const frameRef = meta.frames[fi];
-            if (frameRef.s + frameRef.l > binarySection.length) {
-              throw new Error(
-                `Animation frame ref out of bounds: offset ${frameRef.s} + length ${frameRef.l} ` +
-                  `exceeds binary section size ${binarySection.length}`,
-              );
-            }
-            const compressedFrame = binarySection.subarray(
-              frameRef.s,
-              frameRef.s + frameRef.l,
-            );
-            const decompressedFrame = lz4Decompress(
-              compressedFrame,
-              frameRef.u,
-              `anim_${item.n}_${fi}`,
-            );
-
-            let rawBuffer: Uint8Array;
-            if (!("t" in frameRef) || frameRef.t === "m") {
-              // Master frame (or legacy frame without 't' field)
-              rawBuffer = decompressedFrame;
-            } else {
-              // Cropped frame: apply rects to base
-              const croppedRef = frameRef as EIAAnimationFrameRefCropped;
-              const baseBuffer = animFrameBuffers.get(croppedRef.b);
-              if (!baseBuffer) {
+            for (let fi = 0; fi < meta.frames.length; fi++) {
+              const frameRef = meta.frames[fi];
+              if (frameRef.s + frameRef.l > binarySection.length) {
                 throw new Error(
-                  `Animation base frame ${croppedRef.b} not found for cropped frame ${fi}`,
+                  `Animation frame ref out of bounds: offset ${frameRef.s} + length ${frameRef.l} ` +
+                    `exceeds binary section size ${binarySection.length}`,
                 );
               }
-              rawBuffer = applyRects(
-                baseBuffer,
-                decompressedFrame,
-                croppedRef.r,
-                meta.w,
-                meta.f,
+              const compressedFrame = binarySection.subarray(
+                frameRef.s,
+                frameRef.s + frameRef.l,
               );
-            }
+              const decompressedFrame = lz4Decompress(
+                compressedFrame,
+                frameRef.u,
+                `anim_${item.n}_${fi}`,
+              );
 
-            animFrameBuffers.set(fi, rawBuffer);
-            animFrames.push(rawToImageData(rawBuffer, meta.w, meta.h, meta.f));
+              let rawBuffer: Uint8Array;
+              if (!("t" in frameRef) || frameRef.t === "m") {
+                // Master frame (or legacy frame without 't' field)
+                rawBuffer = decompressedFrame;
+              } else {
+                // Cropped frame: apply rects to base
+                const croppedRef = frameRef as EIAAnimationFrameRefCropped;
+                const baseBuffer = animFrameBuffers.get(croppedRef.b);
+                if (!baseBuffer) {
+                  throw new Error(
+                    `Animation base frame ${croppedRef.b} not found for cropped frame ${fi}`,
+                  );
+                }
+                rawBuffer = applyRects(
+                  baseBuffer,
+                  decompressedFrame,
+                  croppedRef.r,
+                  meta.w,
+                  meta.f,
+                );
+              }
 
-            // Release buffer if not needed as base for future frames
-            if (!animBaseIndices.has(fi)) {
-              animFrameBuffers.delete(fi);
+              animFrameBuffers.set(fi, rawBuffer);
+              animFrames.push(
+                rawToImageData(rawBuffer, meta.w, meta.h, meta.f),
+              );
+
+              // Release buffer if not needed as base for future frames
+              if (!animBaseIndices.has(fi)) {
+                animFrameBuffers.delete(fi);
+              }
             }
-          }
-          return {
-            x: meta.x,
-            y: meta.y,
-            w: meta.w,
-            h: meta.h,
-            fps: meta.fps,
-            frames: animFrames,
-          };
-        });
-      } catch (e) {
-        console.warn(`Failed to decode animation for frame "${item.n}":`, e);
+            return {
+              x: meta.x,
+              y: meta.y,
+              w: meta.w,
+              h: meta.h,
+              fps: meta.fps,
+              frames: animFrames,
+            };
+          });
+        } catch (e) {
+          console.warn(`Failed to decode animation for frame "${item.n}":`, e);
+        }
       }
     }
 

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -174,81 +174,105 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): SlideFrame[] => {
           `Animation data for frame "${item.n}" cannot be decoded under lz4-base64 compression`,
         );
       } else {
+        let animMetas: EIAAnimationMeta[] = [];
         try {
-          const animMetas: EIAAnimationMeta[] = JSON.parse(item.e.a);
-          animations = animMetas.map((meta) => {
-            const animFrames: ImageData[] = [];
-            const animFrameBuffers = new Map<number, Uint8Array>();
+          const parsed = JSON.parse(item.e.a);
+          if (!Array.isArray(parsed)) {
+            throw new Error("Animation metadata must be an array");
+          }
+          animMetas = parsed as EIAAnimationMeta[];
+        } catch (e) {
+          console.warn(
+            `Failed to parse animation metadata for frame "${item.n}":`,
+            e,
+          );
+        }
 
-            // Pre-scan to find which frames are referenced as base by cropped frames
-            const animBaseIndices = new Set<number>();
-            for (const fr of meta.frames) {
-              if ("t" in fr && fr.t === "c") {
-                animBaseIndices.add((fr as EIAAnimationFrameRefCropped).b);
+        const decodedAnimations = animMetas
+          .map((meta, metaIndex): SlideAnimation | null => {
+            try {
+              const animFrames: ImageData[] = [];
+              const animFrameBuffers = new Map<number, Uint8Array>();
+
+              // Pre-scan to find which frames are referenced as base by cropped frames
+              const animBaseIndices = new Set<number>();
+              for (const fr of meta.frames) {
+                if ("t" in fr && fr.t === "c") {
+                  animBaseIndices.add((fr as EIAAnimationFrameRefCropped).b);
+                }
               }
-            }
 
-            for (let fi = 0; fi < meta.frames.length; fi++) {
-              const frameRef = meta.frames[fi];
-              if (frameRef.s + frameRef.l > binarySection.length) {
-                throw new Error(
-                  `Animation frame ref out of bounds: offset ${frameRef.s} + length ${frameRef.l} ` +
-                    `exceeds binary section size ${binarySection.length}`,
-                );
-              }
-              const compressedFrame = binarySection.subarray(
-                frameRef.s,
-                frameRef.s + frameRef.l,
-              );
-              const decompressedFrame = lz4Decompress(
-                compressedFrame,
-                frameRef.u,
-                `anim_${item.n}_${fi}`,
-              );
-
-              let rawBuffer: Uint8Array;
-              if (!("t" in frameRef) || frameRef.t === "m") {
-                // Master frame (or legacy frame without 't' field)
-                rawBuffer = decompressedFrame;
-              } else {
-                // Cropped frame: apply rects to base
-                const croppedRef = frameRef as EIAAnimationFrameRefCropped;
-                const baseBuffer = animFrameBuffers.get(croppedRef.b);
-                if (!baseBuffer) {
+              for (let fi = 0; fi < meta.frames.length; fi++) {
+                const frameRef = meta.frames[fi];
+                if (frameRef.s + frameRef.l > binarySection.length) {
                   throw new Error(
-                    `Animation base frame ${croppedRef.b} not found for cropped frame ${fi}`,
+                    `Animation frame ref out of bounds: offset ${frameRef.s} + length ${frameRef.l} ` +
+                      `exceeds binary section size ${binarySection.length}`,
                   );
                 }
-                rawBuffer = applyRects(
-                  baseBuffer,
-                  decompressedFrame,
-                  croppedRef.r,
-                  meta.w,
-                  meta.f,
+                const compressedFrame = binarySection.subarray(
+                  frameRef.s,
+                  frameRef.s + frameRef.l,
                 );
-              }
+                const decompressedFrame = lz4Decompress(
+                  compressedFrame,
+                  frameRef.u,
+                  `anim_${item.n}_${metaIndex}_${fi}`,
+                );
 
-              animFrameBuffers.set(fi, rawBuffer);
-              animFrames.push(
-                rawToImageData(rawBuffer, meta.w, meta.h, meta.f),
+                let rawBuffer: Uint8Array;
+                if (!("t" in frameRef) || frameRef.t === "m") {
+                  // Master frame (or legacy frame without 't' field)
+                  rawBuffer = decompressedFrame;
+                } else {
+                  // Cropped frame: apply rects to base
+                  const croppedRef = frameRef as EIAAnimationFrameRefCropped;
+                  const baseBuffer = animFrameBuffers.get(croppedRef.b);
+                  if (!baseBuffer) {
+                    throw new Error(
+                      `Animation base frame ${croppedRef.b} not found for cropped frame ${fi}`,
+                    );
+                  }
+                  rawBuffer = applyRects(
+                    baseBuffer,
+                    decompressedFrame,
+                    croppedRef.r,
+                    meta.w,
+                    meta.f,
+                  );
+                }
+
+                animFrameBuffers.set(fi, rawBuffer);
+                animFrames.push(
+                  rawToImageData(rawBuffer, meta.w, meta.h, meta.f),
+                );
+
+                // Release buffer if not needed as base for future frames
+                if (!animBaseIndices.has(fi)) {
+                  animFrameBuffers.delete(fi);
+                }
+              }
+              return {
+                x: meta.x,
+                y: meta.y,
+                w: meta.w,
+                h: meta.h,
+                fps: meta.fps,
+                frames: animFrames,
+              };
+            } catch (e) {
+              console.warn(
+                `Failed to decode animation meta index ${metaIndex} for frame "${item.n}":`,
+                meta,
+                e,
               );
-
-              // Release buffer if not needed as base for future frames
-              if (!animBaseIndices.has(fi)) {
-                animFrameBuffers.delete(fi);
-              }
+              return null;
             }
-            return {
-              x: meta.x,
-              y: meta.y,
-              w: meta.w,
-              h: meta.h,
-              fps: meta.fps,
-              frames: animFrames,
-            };
-          });
-        } catch (e) {
-          console.warn(`Failed to decode animation for frame "${item.n}":`, e);
+          })
+          .filter((anim): anim is SlideAnimation => anim !== null);
+
+        if (decodedAnimations.length > 0) {
+          animations = decodedAnimations;
         }
       }
     }

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -157,39 +157,23 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): SlideFrame[] => {
     if (!Number.isFinite(index))
       throw new Error(`Non-numeric frame name: "${item.n}"`);
 
-    // Decode animation data from e.a extension
+    // Decode animation data from e.a extension (binary lz4 only)
     let animations: SlideAnimation[] | undefined;
-    if (item.e?.a) {
+    if (item.e?.a && binarySection !== null) {
       try {
         const animMetas: EIAAnimationMeta[] = JSON.parse(item.e.a);
         animations = animMetas.map((meta) => {
           const animFrames: ImageData[] = [];
           for (const frameRef of meta.frames) {
-            let decompressedFrame: Uint8Array;
-            if (binarySection !== null) {
-              const compressedFrame = binarySection.subarray(
-                frameRef.s,
-                frameRef.s + frameRef.l,
-              );
-              decompressedFrame = lz4Decompress(
-                compressedFrame,
-                frameRef.u,
-                `anim_${item.n}`,
-              );
-            } else if (textSection !== null) {
-              const b64Frame = textSection.substring(
-                frameRef.s,
-                frameRef.s + frameRef.l,
-              );
-              const compressedFrame = base64ToUint8Array(b64Frame);
-              decompressedFrame = lz4Decompress(
-                compressedFrame,
-                frameRef.u,
-                `anim_${item.n}`,
-              );
-            } else {
-              throw new Error(`Unsupported compression: ${manifest.c}`);
-            }
+            const compressedFrame = binarySection.subarray(
+              frameRef.s,
+              frameRef.s + frameRef.l,
+            );
+            const decompressedFrame = lz4Decompress(
+              compressedFrame,
+              frameRef.u,
+              `anim_${item.n}`,
+            );
             animFrames.push(
               rawToImageData(decompressedFrame, meta.w, meta.h, meta.f),
             );

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -168,6 +168,11 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): SlideFrame[] => {
 
     // Decode animation data from e.a extension (binary lz4 only)
     let animations: SlideAnimation[] | undefined;
+    if (item.e?.a && binarySection === null) {
+      console.warn(
+        `Animation data for frame "${item.n}" cannot be decoded under lz4-base64 compression`,
+      );
+    }
     if (item.e?.a && binarySection !== null) {
       try {
         const animMetas: EIAAnimationMeta[] = JSON.parse(item.e.a);

--- a/src/lib/workerService/postCompress.ts
+++ b/src/lib/workerService/postCompress.ts
@@ -33,6 +33,7 @@ export const postCompress = (
         const animBitmaps = anim.frames.map((frame) => {
           const bm = frame.transferToImageBitmap();
           transferables.push(bm);
+          frame.close(); // Release the now-empty canvas backing store
           return bm;
         });
         return {
@@ -66,13 +67,12 @@ export const postCompress = (
   };
   console.log("postCompress", message);
   return new Promise<string[] | Buffer[]>((resolve) => {
-    worker.addEventListener(
-      "message",
-      (event: MessageEvent<WorkerResponse>) => {
-        if (event.data.type !== "compress") return;
-        resolve(event.data.data);
-      },
-    );
+    const handler = (event: MessageEvent<WorkerResponse>) => {
+      if (event.data.type !== "compress") return;
+      worker.removeEventListener("message", handler);
+      resolve(event.data.data);
+    };
+    worker.addEventListener("message", handler);
     worker.postMessage(message, transferables);
   });
 };

--- a/src/lib/workerService/postCompress.ts
+++ b/src/lib/workerService/postCompress.ts
@@ -61,13 +61,43 @@ export const postCompress = (
     },
   };
   console.log("postCompress", message);
-  return new Promise<string[] | Buffer[]>((resolve) => {
+  return new Promise<string[] | Buffer[]>((resolve, reject) => {
     const handler = (event: MessageEvent<WorkerResponse>) => {
-      if (event.data.type !== "compress") return;
+      if (event.data.type === "compress") {
+        cleanup();
+        resolve(event.data.data);
+        return;
+      }
+      if (event.data.type === "compress-error") {
+        cleanup();
+        reject(new Error(event.data.error));
+      }
+    };
+    const errorHandler = (event: ErrorEvent) => {
+      cleanup();
+      reject(
+        event.error instanceof Error
+          ? event.error
+          : new Error(event.message || "Compression worker failed"),
+      );
+    };
+    const messageErrorHandler = () => {
+      cleanup();
+      reject(new Error("Compression worker message error"));
+    };
+    const cleanup = () => {
       worker.removeEventListener("message", handler);
-      resolve(event.data.data);
+      worker.removeEventListener("error", errorHandler);
+      worker.removeEventListener("messageerror", messageErrorHandler);
     };
     worker.addEventListener("message", handler);
-    worker.postMessage(message, transferables);
+    worker.addEventListener("error", errorHandler);
+    worker.addEventListener("messageerror", messageErrorHandler);
+    try {
+      worker.postMessage(message, transferables);
+    } catch (e) {
+      cleanup();
+      reject(e instanceof Error ? e : new Error(String(e)));
+    }
   });
 };

--- a/src/lib/workerService/postCompress.ts
+++ b/src/lib/workerService/postCompress.ts
@@ -1,6 +1,10 @@
 import type { SelectedFile } from "@/_types/file-picker";
 import type { TTextureConverterFormat } from "@/_types/text-zip/formats";
-import type { WorkerMessage, WorkerResponse } from "@/_types/worker";
+import type {
+  WorkerAnimationBitmap,
+  WorkerMessage,
+  WorkerResponse,
+} from "@/_types/worker";
 import type { Resolution } from "@/const/resolutions";
 
 const worker = (
@@ -17,6 +21,39 @@ export const postCompress = (
   resolution: Resolution,
 ): Promise<string[] | Buffer[]> => {
   console.log("postCompress");
+
+  const transferables: Transferable[] = [];
+  const workerFiles = files.map((file) => {
+    const bitmap = file.canvas.transferToImageBitmap();
+    transferables.push(bitmap);
+
+    let animations: WorkerAnimationBitmap[] | undefined;
+    if (file.animations && file.animations.length > 0) {
+      animations = file.animations.map((anim) => {
+        const animBitmaps = anim.frames.map((frame) => {
+          const bm = frame.transferToImageBitmap();
+          transferables.push(bm);
+          return bm;
+        });
+        return {
+          x: anim.x,
+          y: anim.y,
+          w: anim.w,
+          h: anim.h,
+          fps: anim.fps,
+          frames: animBitmaps,
+        };
+      });
+    }
+
+    return {
+      ...file,
+      bitmap,
+      canvas: undefined as unknown as OffscreenCanvas,
+      animations,
+    };
+  });
+
   const message: WorkerMessage = {
     type: "compress",
     data: {
@@ -24,11 +61,7 @@ export const postCompress = (
       version,
       scale,
       resolution,
-      files: files.map((file) => ({
-        ...file,
-        bitmap: file.canvas.transferToImageBitmap(),
-        canvas: undefined,
-      })),
+      files: workerFiles,
     },
   };
   console.log("postCompress", message);
@@ -40,9 +73,6 @@ export const postCompress = (
         resolve(event.data.data);
       },
     );
-    worker.postMessage(
-      message,
-      message.data.files.map((file) => file.bitmap),
-    );
+    worker.postMessage(message, transferables);
   });
 };

--- a/src/lib/workerService/postCompress.ts
+++ b/src/lib/workerService/postCompress.ts
@@ -33,7 +33,6 @@ export const postCompress = (
         const animBitmaps = anim.frames.map((frame) => {
           const bm = frame.transferToImageBitmap();
           transferables.push(bm);
-          frame.close(); // Release the now-empty canvas backing store
           return bm;
         });
         return {

--- a/src/lib/workerService/postCompress.ts
+++ b/src/lib/workerService/postCompress.ts
@@ -47,12 +47,8 @@ export const postCompress = (
       });
     }
 
-    return {
-      ...file,
-      bitmap,
-      canvas: undefined as unknown as OffscreenCanvas,
-      animations,
-    };
+    const { canvas: _canvas, animations: _origAnimations, ...fileRest } = file;
+    return { ...fileRest, bitmap, animations };
   });
 
   const message: WorkerMessage = {

--- a/src/lib/workerService/postCompressSignage.ts
+++ b/src/lib/workerService/postCompressSignage.ts
@@ -30,7 +30,8 @@ export const postCompressSignage = (
       files: files.map((file) => ({
         ...file,
         bitmap: file.canvas.transferToImageBitmap(),
-        canvas: undefined,
+        canvas: undefined as unknown as OffscreenCanvas,
+        animations: undefined,
       })),
     },
   };

--- a/src/lib/workerService/postCompressSignage.ts
+++ b/src/lib/workerService/postCompressSignage.ts
@@ -27,12 +27,11 @@ export const postCompressSignage = (
       signage,
       scale,
       resolution,
-      files: files.map((file) => ({
-        ...file,
-        bitmap: file.canvas.transferToImageBitmap(),
-        canvas: undefined as unknown as OffscreenCanvas,
-        animations: undefined,
-      })),
+      files: files.map((file) => {
+        const bitmap = file.canvas.transferToImageBitmap();
+        const { canvas: _canvas, animations: _animations, ...fileRest } = file;
+        return { ...fileRest, bitmap };
+      }),
     },
   };
   console.log("postCompressSignage", message);

--- a/src/lib/workerService/postCompressSignage.ts
+++ b/src/lib/workerService/postCompressSignage.ts
@@ -37,14 +37,13 @@ export const postCompressSignage = (
   };
   console.log("postCompressSignage", message);
   return new Promise<string[] | Buffer[]>((resolve) => {
-    worker.addEventListener(
-      "message",
-      (event: MessageEvent<WorkerResponse>) => {
-        if (event.data.type !== "compress-signage") return;
-        console.log("postCompressSignage response", event.data);
-        resolve(event.data.data);
-      },
-    );
+    const handler = (event: MessageEvent<WorkerResponse>) => {
+      if (event.data.type !== "compress-signage") return;
+      worker.removeEventListener("message", handler);
+      console.log("postCompressSignage response", event.data);
+      resolve(event.data.data);
+    };
+    worker.addEventListener("message", handler);
     worker.postMessage(
       message,
       message.data.files.map((file) => file.bitmap),

--- a/src/lib/workerService/postCompressSignage.ts
+++ b/src/lib/workerService/postCompressSignage.ts
@@ -36,17 +36,47 @@ export const postCompressSignage = (
     },
   };
   console.log("postCompressSignage", message);
-  return new Promise<string[] | Buffer[]>((resolve) => {
+  return new Promise<string[] | Buffer[]>((resolve, reject) => {
     const handler = (event: MessageEvent<WorkerResponse>) => {
-      if (event.data.type !== "compress-signage") return;
+      if (event.data.type === "compress-signage") {
+        cleanup();
+        console.log("postCompressSignage response", event.data);
+        resolve(event.data.data);
+        return;
+      }
+      if (event.data.type === "compress-signage-error") {
+        cleanup();
+        reject(new Error(event.data.error));
+      }
+    };
+    const errorHandler = (event: ErrorEvent) => {
+      cleanup();
+      reject(
+        event.error instanceof Error
+          ? event.error
+          : new Error(event.message || "Signage compression worker failed"),
+      );
+    };
+    const messageErrorHandler = () => {
+      cleanup();
+      reject(new Error("Signage compression worker message error"));
+    };
+    const cleanup = () => {
       worker.removeEventListener("message", handler);
-      console.log("postCompressSignage response", event.data);
-      resolve(event.data.data);
+      worker.removeEventListener("error", errorHandler);
+      worker.removeEventListener("messageerror", messageErrorHandler);
     };
     worker.addEventListener("message", handler);
-    worker.postMessage(
-      message,
-      message.data.files.map((file) => file.bitmap),
-    );
+    worker.addEventListener("error", errorHandler);
+    worker.addEventListener("messageerror", messageErrorHandler);
+    try {
+      worker.postMessage(
+        message,
+        message.data.files.map((file) => file.bitmap),
+      );
+    } catch (e) {
+      cleanup();
+      reject(e instanceof Error ? e : new Error(String(e)));
+    }
   });
 };

--- a/src/lib/workerService/postCompressSignage.ts
+++ b/src/lib/workerService/postCompressSignage.ts
@@ -27,6 +27,7 @@ export const postCompressSignage = (
       signage,
       scale,
       resolution,
+      // Signage path does not support GIF animations; they are intentionally excluded.
       files: files.map((file) => {
         const bitmap = file.canvas.transferToImageBitmap();
         const { canvas: _canvas, animations: _animations, ...fileRest } = file;

--- a/src/worker/compress.ts
+++ b/src/worker/compress.ts
@@ -10,86 +10,97 @@ worker.addEventListener(
   async (event: MessageEvent<WorkerMessage>) => {
     console.log("compress start", event.data);
     if (event.data.type !== "compress") return;
-    const { files: _files, format, scale, resolution } = event.data.data;
+    try {
+      const { files: _files, format, scale, resolution } = event.data.data;
 
-    const files = _files.map((file) => {
-      // ファイルごとにアスペクト比を維持したスケールを計算
-      const resolutionScale = getResolutionScale(
-        resolution,
-        file.bitmap.width,
-        file.bitmap.height,
-      );
+      const files = _files.map((file) => {
+        // ファイルごとにアスペクト比を維持したスケールを計算
+        const resolutionScale = getResolutionScale(
+          resolution,
+          file.bitmap.width,
+          file.bitmap.height,
+        );
 
-      // Compute effective scale for animations and main canvas
-      let effectiveScaleX: number;
-      let effectiveScaleY: number;
-      let canvas: OffscreenCanvas;
+        // Compute effective scale for animations and main canvas
+        let effectiveScaleX: number;
+        let effectiveScaleY: number;
+        let canvas: OffscreenCanvas;
 
-      if (["DXT1"].includes(format)) {
-        // そのままだとノイズが目立つので2倍に拡大してから圧縮
-        const _width = Math.ceil((file.bitmap.width * scale * 2) / 4) * 4;
-        const _height = Math.ceil((file.bitmap.height * scale * 2) / 4) * 4;
-        effectiveScaleX = _width / file.bitmap.width;
-        effectiveScaleY = _height / file.bitmap.height;
-        canvas = new OffscreenCanvas(_width, _height);
-        if (_width === file.bitmap.width && _height === file.bitmap.height) {
-          canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
+        if (["DXT1"].includes(format)) {
+          // そのままだとノイズが目立つので2倍に拡大してから圧縮
+          const _width = Math.ceil((file.bitmap.width * scale * 2) / 4) * 4;
+          const _height = Math.ceil((file.bitmap.height * scale * 2) / 4) * 4;
+          effectiveScaleX = _width / file.bitmap.width;
+          effectiveScaleY = _height / file.bitmap.height;
+          canvas = new OffscreenCanvas(_width, _height);
+          if (_width === file.bitmap.width && _height === file.bitmap.height) {
+            canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
+          } else {
+            canvas
+              .getContext("2d")
+              ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
+          }
         } else {
-          canvas
-            .getContext("2d")
-            ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
+          const finalScale = scale * resolutionScale;
+          effectiveScaleX = finalScale;
+          effectiveScaleY = finalScale;
+          if (finalScale === 1) {
+            canvas = new OffscreenCanvas(file.bitmap.width, file.bitmap.height);
+            canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
+          } else {
+            canvas = new OffscreenCanvas(
+              Math.round(file.bitmap.width * finalScale),
+              Math.round(file.bitmap.height * finalScale),
+            );
+            canvas
+              .getContext("2d")
+              ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
+          }
         }
-      } else {
-        const finalScale = scale * resolutionScale;
-        effectiveScaleX = finalScale;
-        effectiveScaleY = finalScale;
-        if (finalScale === 1) {
-          canvas = new OffscreenCanvas(file.bitmap.width, file.bitmap.height);
-          canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
-        } else {
-          canvas = new OffscreenCanvas(
-            Math.round(file.bitmap.width * finalScale),
-            Math.round(file.bitmap.height * finalScale),
-          );
-          canvas
-            .getContext("2d")
-            ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
+
+        // Convert animation bitmaps to OffscreenCanvas with scaling applied
+        let animations: SelectedFileAnimation[] | undefined;
+        if (file.animations && file.animations.length > 0) {
+          animations = file.animations.map((anim) => ({
+            x: Math.round(anim.x * effectiveScaleX),
+            y: Math.round(anim.y * effectiveScaleY),
+            w: Math.round(anim.w * effectiveScaleX),
+            h: Math.round(anim.h * effectiveScaleY),
+            fps: anim.fps,
+            frames: anim.frames.map((bm) => {
+              const scaledW = Math.round(bm.width * effectiveScaleX);
+              const scaledH = Math.round(bm.height * effectiveScaleY);
+              const c = new OffscreenCanvas(scaledW, scaledH);
+              const ctx = c.getContext("2d");
+              if (!ctx)
+                throw new Error("Cannot get 2d context for animation frame");
+              ctx.drawImage(bm, 0, 0, scaledW, scaledH);
+              bm.close();
+              return c;
+            }),
+          }));
         }
-      }
 
-      // Convert animation bitmaps to OffscreenCanvas with scaling applied
-      let animations: SelectedFileAnimation[] | undefined;
-      if (file.animations && file.animations.length > 0) {
-        animations = file.animations.map((anim) => ({
-          x: Math.round(anim.x * effectiveScaleX),
-          y: Math.round(anim.y * effectiveScaleY),
-          w: Math.round(anim.w * effectiveScaleX),
-          h: Math.round(anim.h * effectiveScaleY),
-          fps: anim.fps,
-          frames: anim.frames.map((bm) => {
-            const scaledW = Math.round(bm.width * effectiveScaleX);
-            const scaledH = Math.round(bm.height * effectiveScaleY);
-            const c = new OffscreenCanvas(scaledW, scaledH);
-            const ctx = c.getContext("2d");
-            if (!ctx)
-              throw new Error("Cannot get 2d context for animation frame");
-            ctx.drawImage(bm, 0, 0, scaledW, scaledH);
-            bm.close();
-            return c;
-          }),
-        }));
-      }
-
-      return { ...file, canvas, animations };
-    });
-    console.log("compress", files);
-    const converter = TargetFormats.find((f) => f.id === format)?.converter;
-    if (!converter) throw new Error("converter not found");
-    const result = await converter(files);
-    const message: WorkerResponse = {
-      type: "compress",
-      data: result,
-    };
-    worker.postMessage(message);
+        return { ...file, canvas, animations };
+      });
+      console.log("compress", files);
+      const converter = TargetFormats.find((f) => f.id === format)?.converter;
+      if (!converter) throw new Error("converter not found");
+      const result = await converter(files);
+      const message: WorkerResponse = {
+        type: "compress",
+        data: result,
+      };
+      worker.postMessage(message);
+    } catch (e) {
+      const error =
+        e instanceof Error ? e.message : "Unknown error in compression worker";
+      console.error("compress worker failed:", e);
+      const message: WorkerResponse = {
+        type: "compress-error",
+        error,
+      };
+      worker.postMessage(message);
+    }
   },
 );

--- a/src/worker/compress.ts
+++ b/src/worker/compress.ts
@@ -31,7 +31,11 @@ worker.addEventListener(
           fps: anim.fps,
           frames: anim.frames.map((bm) => {
             const c = new OffscreenCanvas(bm.width, bm.height);
-            c.getContext("2d")?.drawImage(bm, 0, 0);
+            const ctx = c.getContext("2d");
+            if (!ctx)
+              throw new Error("Cannot get 2d context for animation frame");
+            ctx.drawImage(bm, 0, 0);
+            bm.close();
             return c;
           }),
         }));

--- a/src/worker/compress.ts
+++ b/src/worker/compress.ts
@@ -20,64 +20,66 @@ worker.addEventListener(
         file.bitmap.height,
       );
 
-      // Convert animation bitmaps to OffscreenCanvas
+      // Compute effective scale for animations and main canvas
+      let effectiveScaleX: number;
+      let effectiveScaleY: number;
+      let canvas: OffscreenCanvas;
+
+      if (["DXT1"].includes(format)) {
+        // そのままだとノイズが目立つので2倍に拡大してから圧縮
+        const _width = Math.ceil((file.bitmap.width * scale * 2) / 4) * 4;
+        const _height = Math.ceil((file.bitmap.height * scale * 2) / 4) * 4;
+        effectiveScaleX = _width / file.bitmap.width;
+        effectiveScaleY = _height / file.bitmap.height;
+        canvas = new OffscreenCanvas(_width, _height);
+        if (_width === file.bitmap.width && _height === file.bitmap.height) {
+          canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
+        } else {
+          canvas
+            .getContext("2d")
+            ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
+        }
+      } else {
+        const finalScale = scale * resolutionScale;
+        effectiveScaleX = finalScale;
+        effectiveScaleY = finalScale;
+        if (finalScale === 1) {
+          canvas = new OffscreenCanvas(file.bitmap.width, file.bitmap.height);
+          canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
+        } else {
+          canvas = new OffscreenCanvas(
+            Math.round(file.bitmap.width * finalScale),
+            Math.round(file.bitmap.height * finalScale),
+          );
+          canvas
+            .getContext("2d")
+            ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
+        }
+      }
+
+      // Convert animation bitmaps to OffscreenCanvas with scaling applied
       let animations: SelectedFileAnimation[] | undefined;
       if (file.animations && file.animations.length > 0) {
         animations = file.animations.map((anim) => ({
-          x: anim.x,
-          y: anim.y,
-          w: anim.w,
-          h: anim.h,
+          x: Math.round(anim.x * effectiveScaleX),
+          y: Math.round(anim.y * effectiveScaleY),
+          w: Math.round(anim.w * effectiveScaleX),
+          h: Math.round(anim.h * effectiveScaleY),
           fps: anim.fps,
           frames: anim.frames.map((bm) => {
-            const c = new OffscreenCanvas(bm.width, bm.height);
+            const scaledW = Math.round(bm.width * effectiveScaleX);
+            const scaledH = Math.round(bm.height * effectiveScaleY);
+            const c = new OffscreenCanvas(scaledW, scaledH);
             const ctx = c.getContext("2d");
             if (!ctx)
               throw new Error("Cannot get 2d context for animation frame");
-            ctx.drawImage(bm, 0, 0);
+            ctx.drawImage(bm, 0, 0, scaledW, scaledH);
             bm.close();
             return c;
           }),
         }));
       }
 
-      if (["DXT1"].includes(format)) {
-        // そのままだとノイズが目立つので2倍に拡大してから圧縮
-        const _width = Math.ceil((file.bitmap.width * scale * 2) / 4) * 4;
-        const _height = Math.ceil((file.bitmap.height * scale * 2) / 4) * 4;
-        if (_width === file.bitmap.width && _height === file.bitmap.height) {
-          const canvas = new OffscreenCanvas(
-            file.bitmap.width,
-            file.bitmap.height,
-          );
-          canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
-          return { ...file, canvas, animations };
-        }
-        const canvas = new OffscreenCanvas(_width, _height);
-        canvas
-          .getContext("2d")
-          ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
-        return { ...file, canvas, animations };
-      }
-
-      // 解像度とscaleの両方を考慮した最終スケール
-      const finalScale = scale * resolutionScale;
-
-      if (finalScale === 1) {
-        const canvas = new OffscreenCanvas(
-          file.bitmap.width,
-          file.bitmap.height,
-        );
-        canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
-        return { ...file, canvas, animations };
-      }
-      const canvas = new OffscreenCanvas(
-        Math.round(file.bitmap.width * finalScale),
-        Math.round(file.bitmap.height * finalScale),
-      );
-      canvas
-        .getContext("2d")
-        ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
       return { ...file, canvas, animations };
     });
     console.log("compress", files);

--- a/src/worker/compress.ts
+++ b/src/worker/compress.ts
@@ -14,93 +14,101 @@ worker.addEventListener(
       const { files: _files, format, scale, resolution } = event.data.data;
 
       const files = _files.map((file) => {
-        // ファイルごとにアスペクト比を維持したスケールを計算
-        const resolutionScale = getResolutionScale(
-          resolution,
-          file.bitmap.width,
-          file.bitmap.height,
-        );
-
-        // Compute effective scale for animations and main canvas
-        let effectiveScaleX: number;
-        let effectiveScaleY: number;
-        let canvas: OffscreenCanvas;
-
-        if (["DXT1"].includes(format)) {
-          // そのままだとノイズが目立つので2倍に拡大してから圧縮
-          const _width = Math.max(
-            4,
-            Math.ceil((file.bitmap.width * scale * 2) / 4) * 4,
+        try {
+          // ファイルごとにアスペクト比を維持したスケールを計算
+          const resolutionScale = getResolutionScale(
+            resolution,
+            file.bitmap.width,
+            file.bitmap.height,
           );
-          const _height = Math.max(
-            4,
-            Math.ceil((file.bitmap.height * scale * 2) / 4) * 4,
-          );
-          effectiveScaleX = _width / file.bitmap.width;
-          effectiveScaleY = _height / file.bitmap.height;
-          canvas = new OffscreenCanvas(_width, _height);
-          if (_width === file.bitmap.width && _height === file.bitmap.height) {
-            canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
-          } else {
-            canvas
-              .getContext("2d")
-              ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
-          }
-        } else {
-          const finalScale = scale * resolutionScale;
-          if (finalScale === 1) {
-            effectiveScaleX = 1;
-            effectiveScaleY = 1;
-            canvas = new OffscreenCanvas(file.bitmap.width, file.bitmap.height);
-            canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
-          } else {
-            const scaledWidth = Math.max(
-              1,
-              Math.round(file.bitmap.width * finalScale),
-            );
-            const scaledHeight = Math.max(
-              1,
-              Math.round(file.bitmap.height * finalScale),
-            );
-            effectiveScaleX = scaledWidth / file.bitmap.width;
-            effectiveScaleY = scaledHeight / file.bitmap.height;
-            canvas = new OffscreenCanvas(scaledWidth, scaledHeight);
-            canvas
-              .getContext("2d")
-              ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
-          }
-        }
 
-        // Convert animation bitmaps to OffscreenCanvas with scaling applied
-        let animations: SelectedFileAnimation[] | undefined;
-        if (file.animations && file.animations.length > 0) {
-          animations = file.animations.map((anim) => ({
-            x: Math.round(anim.x * effectiveScaleX),
-            y: Math.round(anim.y * effectiveScaleY),
-            w: Math.max(1, Math.round(anim.w * effectiveScaleX)),
-            h: Math.max(1, Math.round(anim.h * effectiveScaleY)),
-            fps: anim.fps,
-            frames: anim.frames.map((bm) => {
-              const scaledW = Math.max(
-                1,
-                Math.round(bm.width * effectiveScaleX),
-              );
-              const scaledH = Math.max(
-                1,
-                Math.round(bm.height * effectiveScaleY),
-              );
-              const c = new OffscreenCanvas(scaledW, scaledH);
-              const ctx = c.getContext("2d");
-              if (!ctx)
-                throw new Error("Cannot get 2d context for animation frame");
-              ctx.drawImage(bm, 0, 0, scaledW, scaledH);
-              bm.close();
-              return c;
-            }),
-          }));
-        }
+          // Compute effective scale for animations and main canvas
+          let effectiveScaleX: number;
+          let effectiveScaleY: number;
+          let canvas: OffscreenCanvas;
 
-        return { ...file, canvas, animations };
+          if (["DXT1"].includes(format)) {
+            // そのままだとノイズが目立つので2倍に拡大してから圧縮
+            const _width = Math.max(
+              4,
+              Math.ceil((file.bitmap.width * scale * 2) / 4) * 4,
+            );
+            const _height = Math.max(
+              4,
+              Math.ceil((file.bitmap.height * scale * 2) / 4) * 4,
+            );
+            effectiveScaleX = _width / file.bitmap.width;
+            effectiveScaleY = _height / file.bitmap.height;
+            canvas = new OffscreenCanvas(_width, _height);
+          } else {
+            const finalScale = scale * resolutionScale;
+            if (finalScale === 1) {
+              effectiveScaleX = 1;
+              effectiveScaleY = 1;
+              canvas = new OffscreenCanvas(
+                file.bitmap.width,
+                file.bitmap.height,
+              );
+            } else {
+              const scaledWidth = Math.max(
+                1,
+                Math.round(file.bitmap.width * finalScale),
+              );
+              const scaledHeight = Math.max(
+                1,
+                Math.round(file.bitmap.height * finalScale),
+              );
+              effectiveScaleX = scaledWidth / file.bitmap.width;
+              effectiveScaleY = scaledHeight / file.bitmap.height;
+              canvas = new OffscreenCanvas(scaledWidth, scaledHeight);
+            }
+          }
+
+          const canvasCtx = canvas.getContext("2d");
+          if (!canvasCtx)
+            throw new Error("Failed to get 2D context for canvas");
+          if (
+            canvas.width === file.bitmap.width &&
+            canvas.height === file.bitmap.height
+          ) {
+            canvasCtx.drawImage(file.bitmap, 0, 0);
+          } else {
+            canvasCtx.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
+          }
+
+          // Convert animation bitmaps to OffscreenCanvas with scaling applied
+          let animations: SelectedFileAnimation[] | undefined;
+          if (file.animations && file.animations.length > 0) {
+            animations = file.animations.map((anim) => ({
+              x: Math.round(anim.x * effectiveScaleX),
+              y: Math.round(anim.y * effectiveScaleY),
+              w: Math.max(1, Math.round(anim.w * effectiveScaleX)),
+              h: Math.max(1, Math.round(anim.h * effectiveScaleY)),
+              fps: anim.fps,
+              frames: anim.frames.map((bm) => {
+                const scaledW = Math.max(
+                  1,
+                  Math.round(bm.width * effectiveScaleX),
+                );
+                const scaledH = Math.max(
+                  1,
+                  Math.round(bm.height * effectiveScaleY),
+                );
+                const c = new OffscreenCanvas(scaledW, scaledH);
+                const ctx = c.getContext("2d");
+                if (!ctx)
+                  throw new Error("Cannot get 2d context for animation frame");
+                ctx.drawImage(bm, 0, 0, scaledW, scaledH);
+                bm.close();
+                return c;
+              }),
+            }));
+          }
+
+          return { ...file, canvas, animations };
+        } finally {
+          file.bitmap.close();
+        }
       });
       console.log("compress", files);
       const converter = TargetFormats.find((f) => f.id === format)?.converter;

--- a/src/worker/compress.ts
+++ b/src/worker/compress.ts
@@ -1,3 +1,4 @@
+import type { SelectedFileAnimation } from "@/_types/file-picker";
 import type { WorkerMessage, WorkerResponse } from "@/_types/worker";
 import { TargetFormats } from "@/const/convert";
 import { getResolutionScale } from "@/utils/getResolutionScale";
@@ -19,6 +20,23 @@ worker.addEventListener(
         file.bitmap.height,
       );
 
+      // Convert animation bitmaps to OffscreenCanvas
+      let animations: SelectedFileAnimation[] | undefined;
+      if (file.animations && file.animations.length > 0) {
+        animations = file.animations.map((anim) => ({
+          x: anim.x,
+          y: anim.y,
+          w: anim.w,
+          h: anim.h,
+          fps: anim.fps,
+          frames: anim.frames.map((bm) => {
+            const c = new OffscreenCanvas(bm.width, bm.height);
+            c.getContext("2d")?.drawImage(bm, 0, 0);
+            return c;
+          }),
+        }));
+      }
+
       if (["DXT1"].includes(format)) {
         // そのままだとノイズが目立つので2倍に拡大してから圧縮
         const _width = Math.ceil((file.bitmap.width * scale * 2) / 4) * 4;
@@ -29,13 +47,13 @@ worker.addEventListener(
             file.bitmap.height,
           );
           canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
-          return { ...file, canvas };
+          return { ...file, canvas, animations };
         }
         const canvas = new OffscreenCanvas(_width, _height);
         canvas
           .getContext("2d")
           ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
-        return { ...file, canvas };
+        return { ...file, canvas, animations };
       }
 
       // 解像度とscaleの両方を考慮した最終スケール
@@ -47,7 +65,7 @@ worker.addEventListener(
           file.bitmap.height,
         );
         canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
-        return { ...file, canvas };
+        return { ...file, canvas, animations };
       }
       const canvas = new OffscreenCanvas(
         Math.round(file.bitmap.width * finalScale),
@@ -56,7 +74,7 @@ worker.addEventListener(
       canvas
         .getContext("2d")
         ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
-      return { ...file, canvas };
+      return { ...file, canvas, animations };
     });
     console.log("compress", files);
     const converter = TargetFormats.find((f) => f.id === format)?.converter;

--- a/src/worker/compress.ts
+++ b/src/worker/compress.ts
@@ -28,8 +28,14 @@ worker.addEventListener(
 
         if (["DXT1"].includes(format)) {
           // そのままだとノイズが目立つので2倍に拡大してから圧縮
-          const _width = Math.ceil((file.bitmap.width * scale * 2) / 4) * 4;
-          const _height = Math.ceil((file.bitmap.height * scale * 2) / 4) * 4;
+          const _width = Math.max(
+            4,
+            Math.ceil((file.bitmap.width * scale * 2) / 4) * 4,
+          );
+          const _height = Math.max(
+            4,
+            Math.ceil((file.bitmap.height * scale * 2) / 4) * 4,
+          );
           effectiveScaleX = _width / file.bitmap.width;
           effectiveScaleY = _height / file.bitmap.height;
           canvas = new OffscreenCanvas(_width, _height);
@@ -42,16 +48,23 @@ worker.addEventListener(
           }
         } else {
           const finalScale = scale * resolutionScale;
-          effectiveScaleX = finalScale;
-          effectiveScaleY = finalScale;
           if (finalScale === 1) {
+            effectiveScaleX = 1;
+            effectiveScaleY = 1;
             canvas = new OffscreenCanvas(file.bitmap.width, file.bitmap.height);
             canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
           } else {
-            canvas = new OffscreenCanvas(
+            const scaledWidth = Math.max(
+              1,
               Math.round(file.bitmap.width * finalScale),
+            );
+            const scaledHeight = Math.max(
+              1,
               Math.round(file.bitmap.height * finalScale),
             );
+            effectiveScaleX = scaledWidth / file.bitmap.width;
+            effectiveScaleY = scaledHeight / file.bitmap.height;
+            canvas = new OffscreenCanvas(scaledWidth, scaledHeight);
             canvas
               .getContext("2d")
               ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
@@ -64,12 +77,18 @@ worker.addEventListener(
           animations = file.animations.map((anim) => ({
             x: Math.round(anim.x * effectiveScaleX),
             y: Math.round(anim.y * effectiveScaleY),
-            w: Math.round(anim.w * effectiveScaleX),
-            h: Math.round(anim.h * effectiveScaleY),
+            w: Math.max(1, Math.round(anim.w * effectiveScaleX)),
+            h: Math.max(1, Math.round(anim.h * effectiveScaleY)),
             fps: anim.fps,
             frames: anim.frames.map((bm) => {
-              const scaledW = Math.round(bm.width * effectiveScaleX);
-              const scaledH = Math.round(bm.height * effectiveScaleY);
+              const scaledW = Math.max(
+                1,
+                Math.round(bm.width * effectiveScaleX),
+              );
+              const scaledH = Math.max(
+                1,
+                Math.round(bm.height * effectiveScaleY),
+              );
               const c = new OffscreenCanvas(scaledW, scaledH);
               const ctx = c.getContext("2d");
               if (!ctx)

--- a/src/worker/compressSignage.ts
+++ b/src/worker/compressSignage.ts
@@ -9,50 +9,63 @@ worker.addEventListener(
   async (event: MessageEvent<WorkerMessage>) => {
     console.log("compress start", event.data);
     if (event.data.type !== "compress-signage") return;
-    const {
-      files: _files,
-      format,
-      signage,
-      scale,
-      resolution,
-    } = event.data.data;
-
-    const files = _files.map((file) => {
-      // ファイルごとにアスペクト比を維持したスケールを計算
-      const resolutionScale = getResolutionScale(
+    try {
+      const {
+        files: _files,
+        format,
+        signage,
+        scale,
         resolution,
-        file.bitmap.width,
-        file.bitmap.height,
-      );
-      const finalScale = scale * resolutionScale;
-      const { animations: _a, bitmap: _b, ...rest } = file;
+      } = event.data.data;
 
-      if (finalScale === 1) {
-        const canvas = new OffscreenCanvas(
+      const files = _files.map((file) => {
+        // ファイルごとにアスペクト比を維持したスケールを計算
+        const resolutionScale = getResolutionScale(
+          resolution,
           file.bitmap.width,
           file.bitmap.height,
         );
-        canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
+        const finalScale = scale * resolutionScale;
+        const { animations: _a, bitmap: _b, ...rest } = file;
+
+        if (finalScale === 1) {
+          const canvas = new OffscreenCanvas(
+            file.bitmap.width,
+            file.bitmap.height,
+          );
+          canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
+          return { ...rest, canvas };
+        }
+        const canvas = new OffscreenCanvas(
+          Math.round(file.bitmap.width * finalScale),
+          Math.round(file.bitmap.height * finalScale),
+        );
+        canvas
+          .getContext("2d")
+          ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
         return { ...rest, canvas };
-      }
-      const canvas = new OffscreenCanvas(
-        Math.round(file.bitmap.width * finalScale),
-        Math.round(file.bitmap.height * finalScale),
-      );
-      canvas
-        .getContext("2d")
-        ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
-      return { ...rest, canvas };
-    });
-    console.log("compress", files);
-    const converterObj = TargetFormats.find((f) => f.id === format);
-    if (!converterObj || !converterObj.signageSupport)
-      throw new Error("converter not found");
-    const result = await converterObj.converter(files, signage);
-    const message: WorkerResponse = {
-      type: "compress-signage",
-      data: result,
-    };
-    worker.postMessage(message);
+      });
+      console.log("compress", files);
+      const converterObj = TargetFormats.find((f) => f.id === format);
+      if (!converterObj || !converterObj.signageSupport)
+        throw new Error("converter not found");
+      const result = await converterObj.converter(files, signage);
+      const message: WorkerResponse = {
+        type: "compress-signage",
+        data: result,
+      };
+      worker.postMessage(message);
+    } catch (e) {
+      const error =
+        e instanceof Error
+          ? e.message
+          : "Unknown error in signage compression worker";
+      console.error("compress signage worker failed:", e);
+      const message: WorkerResponse = {
+        type: "compress-signage-error",
+        error,
+      };
+      worker.postMessage(message);
+    }
   },
 );

--- a/src/worker/compressSignage.ts
+++ b/src/worker/compressSignage.ts
@@ -25,6 +25,7 @@ worker.addEventListener(
         file.bitmap.height,
       );
       const finalScale = scale * resolutionScale;
+      const { animations: _a, bitmap: _b, ...rest } = file;
 
       if (finalScale === 1) {
         const canvas = new OffscreenCanvas(
@@ -32,7 +33,7 @@ worker.addEventListener(
           file.bitmap.height,
         );
         canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
-        return { ...file, canvas };
+        return { ...rest, canvas };
       }
       const canvas = new OffscreenCanvas(
         Math.round(file.bitmap.width * finalScale),
@@ -41,7 +42,7 @@ worker.addEventListener(
       canvas
         .getContext("2d")
         ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
-      return { ...file, canvas };
+      return { ...rest, canvas };
     });
     console.log("compress", files);
     const converterObj = TargetFormats.find((f) => f.id === format);

--- a/src/worker/compressSignage.ts
+++ b/src/worker/compressSignage.ts
@@ -27,23 +27,29 @@ worker.addEventListener(
         );
         const finalScale = scale * resolutionScale;
         const { animations: _a, bitmap: _b, ...rest } = file;
-
-        if (finalScale === 1) {
-          const canvas = new OffscreenCanvas(
-            file.bitmap.width,
-            file.bitmap.height,
-          );
-          canvas.getContext("2d")?.drawImage(file.bitmap, 0, 0);
+        const canvas =
+          finalScale === 1
+            ? new OffscreenCanvas(file.bitmap.width, file.bitmap.height)
+            : new OffscreenCanvas(
+                Math.max(1, Math.round(file.bitmap.width * finalScale)),
+                Math.max(1, Math.round(file.bitmap.height * finalScale)),
+              );
+        try {
+          const ctx = canvas.getContext("2d");
+          if (!ctx) {
+            throw new Error(
+              `Cannot get 2d context for signage frame ${file.bitmap.width}x${file.bitmap.height}`,
+            );
+          }
+          if (finalScale === 1) {
+            ctx.drawImage(file.bitmap, 0, 0);
+          } else {
+            ctx.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
+          }
           return { ...rest, canvas };
+        } finally {
+          file.bitmap.close();
         }
-        const canvas = new OffscreenCanvas(
-          Math.round(file.bitmap.width * finalScale),
-          Math.round(file.bitmap.height * finalScale),
-        );
-        canvas
-          .getContext("2d")
-          ?.drawImage(file.bitmap, 0, 0, canvas.width, canvas.height);
-        return { ...rest, canvas };
       });
       console.log("compress", files);
       const converterObj = TargetFormats.find((f) => f.id === format);


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Slides import now detects and extracts animated GIFs, includes per-slide animations in previews and exports.
  * Slide preview overlays and plays extracted animations with correct timing, compositing and scaling.

* **Bug Fixes**
  * Compression flows now show an error toast and avoid navigating on failure.
  * Worker-side failures are surfaced as errors instead of failing silently.

* **Chores**
  * Added GIF runtime dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds GIF animation extraction from Google Slides presentations, stores them in the EIA v1 format with differential compression, and plays them back in the slide preview. All five previously flagged issues (frame-0 delay, RAF timer drift, signage silent drop, unscaled animation coords, `OffscreenCanvas.close()` crash) appear to be resolved in this revision.

One new concern worth noting: `selectedFiles2EIAv1RGB24CroppedBase64.ts` now throws an explicit error when any selected file has animations, which will surface as an error toast for users whose format selection lands on the base64 path (e.g., some iOS/legacy targets). If `getAvailableFormats` doesn't already exclude the base64 format when animations are present, users will see a failure after an otherwise successful import.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all previously flagged P0/P1 blockers are resolved; remaining findings are P2 quality suggestions.

The five previously flagged issues (frame-0 delay, RAF drift, signage silent drop, unscaled animation coords, OffscreenCanvas.close() crash) are all addressed. The two remaining comments are a minor GPU-bitmap leak on mid-decode abort and a UX concern about the base64 format path — neither blocks the primary user flow or causes data loss.

src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24CroppedBase64.ts — verify that format selection excludes this path when animated slides are present.

<details open><summary><h3>Vulnerabilities</h3></summary>

- `extractGifAnimations.ts` fetches GIF content using the user's Google OAuth token and validates the origin against a `TRUSTED_HOSTNAMES` allowlist (`.google.com`, `.googleapis.com`, `.googleusercontent.com`) before issuing any request, which prevents SSRF-style misuse of the bearer token against arbitrary URLs.
- The token is used client-side only, consistent with the existing Google Picker authentication pattern; no new server-side token exposure is introduced.
- No SQL, XSS, or command-injection vectors are introduced. All data paths process binary buffers and ImageData objects.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/google/extractGifAnimations.ts | New file: extracts, samples, and composites animated GIF frames from Google Slides elements; includes trusted-origin validation, range-sniff fetch, disposal-method compositing, and intersection filtering. |
| src/app/(_)/files/[fileId]/_components/SlidePreview.tsx | Adds per-slide animation map and RAF-based playback loop; uses `lastTimes[i] += interval` for drift-free timing; minor resource leak if abort fires during mid-animation-frame decode. |
| src/worker/compress.ts | Correctly computes effectiveScaleX/Y from final canvas dimensions before scaling animation coords; handles DXT1 and non-DXT1 paths separately. |
| src/lib/workerService/postCompress.ts | Transfers animation OffscreenCanvas frames to ImageBitmap before postMessage; no longer calls the non-existent close() method. |
| src/lib/eia/compressEIAv1.ts | Appends animation frames after all slide data; sets fw/fh only when frame dims differ from display dims; correctly partitions animation map per EIA part. |
| src/lib/slidePreview/decodeEIAv1.ts | Decodes animation frames from binary lz4 section with proper bounds checking; gracefully warns and skips on lz4-base64 compression or malformed metadata. |
| src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24CroppedBase64.ts | Explicitly throws when any file has animations; the error surfaces as a toast — safe, but relies on format selection to exclude this path when GIF slides are present. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GP as GooglePicker
    participant EGA as extractGifAnimations
    participant GApi as Google APIs
    participant PC as postCompress
    participant W as compress.ts (Worker)
    participant EIA as selectedFiles2EIAv1RGB24Cropped
    participant SP as SlidePreview
    participant DEC as decodeEIAv1

    GP->>EGA: extractGifAnimations(pageElements, pageSize, canvasSize, canvas, token)
    EGA->>GApi: fetch(contentUrl, Range: bytes=0-5)
    GApi-->>EGA: 206 / 200 (GIF header bytes)
    EGA->>GApi: fetch(contentUrl) [full file if 206]
    GApi-->>EGA: ArrayBuffer
    EGA->>EGA: parseGIF + decompressFrames + sampleFrameIndices
    EGA->>EGA: buildComposedFrames + compositeWithBackground
    EGA-->>GP: SelectedFileAnimation[] (OffscreenCanvas frames)
    GP-->>PC: SelectedFile (canvas + animations)
    PC->>PC: canvas.transferToImageBitmap()
    PC->>PC: anim.frames.map(f => f.transferToImageBitmap())
    PC->>W: postMessage(WorkerMessage, transferables)
    W->>W: compute effectiveScaleX/Y
    W->>W: scale animation x/y/w/h + frame canvases
    W->>EIA: selectedFiles2EIAv1RGB24Cropped(files)
    EIA->>EIA: cropImages (diff compress slide + anim frames)
    EIA->>EIA: compressEIAv1 (append anim data after slides)
    W-->>PC: WorkerResponse (EIA Buffer[])
    SP->>DEC: decodeEIAv1(buffer)
    DEC->>DEC: parse manifest + decompress frames
    DEC->>DEC: decode animation frames from binary section
    DEC-->>SP: SlideFrame[] with animations: SlideAnimation[]
    SP->>SP: imageDataToBitmap per anim frame → animationMap
    SP->>SP: RAF loop: draw base bitmap + overlay anim frames
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
Line: 355-374

Comment:
**ImageBitmaps orphaned on mid-animation abort**

If `controller.signal.aborted` fires after some frames in `animBitmaps` have been created but before the outer `for (const anim of f.animations)` loop completes, those bitmaps are never added to `nextAnimMap` and are therefore not released by the `finally` block (which only cleans up `nextAnimMap.values()`). Each orphaned `ImageBitmap` holds a GPU-backed texture until GC runs.

A simple fix is to track in-progress bitmaps and close them on abort:

```typescript
const animBitmaps: ImageBitmap[] = [];
for (const frameData of anim.frames) {
  if (controller.signal.aborted) {
    for (const bm of animBitmaps) bm.close();
    break;
  }
  animBitmaps.push(await imageDataToBitmap(frameData));
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24CroppedBase64.ts
Line: 14-21

Comment:
**Format selection may route animated slides into the throwing path**

This converter hard-throws when any file has animations. If `getAvailableFormats` (not changed in this PR) can still select this base64 path for a presentation that contains animated GIFs, users will always see the "変換に失敗しました" error toast with no explanation of why. Consider either (a) filtering this format out in `getAvailableFormats` when `selectedFiles.some(f => f.animations?.length)`, or (b) surfacing a more descriptive error message so users know to switch format.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (17): Last reviewed commit: ["Harden GIF processing and stabilize erro..."](https://github.com/o-tr/imageslide-converter/commit/bcd8fa26c1ca1203413ea8191e2d61cd3d82b469) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27489531)</sub>

<!-- /greptile_comment -->