### PR TITLE
EIAのアニメーションプレビューを実装

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,57 +395,57 @@ packages:
     engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==, tarball: https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.29.0':
-    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==, tarball: https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==, tarball: https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==, tarball: https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.28.6':
-    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==, tarball: https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==, tarball: https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.28.6':
-    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==, tarball: https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-transforms@7.28.6':
-    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==, tarball: https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
   '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==, tarball: https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==, tarball: https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==, tarball: https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz}
     engines: {node: '>=6.9.0'}
 
   '@babel/helpers@7.29.2':
-    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==, tarball: https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==, tarball: https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -454,15 +454,15 @@ packages:
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
-    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==, tarball: https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==, tarball: https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==, tarball: https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz}
     engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@1.9.4':
@@ -471,49 +471,53 @@ packages:
     hasBin: true
 
   '@biomejs/cli-darwin-arm64@1.9.4':
-    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==, tarball: https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
   '@biomejs/cli-darwin-x64@1.9.4':
-    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==, tarball: https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
   '@biomejs/cli-linux-arm64-musl@1.9.4':
-    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==, tarball: https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@1.9.4':
-    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==, tarball: https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@1.9.4':
-    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==, tarball: https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@1.9.4':
-    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==, tarball: https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@1.9.4':
-    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==, tarball: https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
   '@biomejs/cli-win32-x64@1.9.4':
-    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==, tarball: https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -547,7 +551,7 @@ packages:
       react: '>=16.8.0'
 
   '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==, tarball: https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz}
 
   '@emotion/hash@0.8.0':
     resolution: {integrity: sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==}
@@ -578,239 +582,267 @@ packages:
     engines: {node: '>=18'}
 
   '@img/sharp-darwin-arm64@0.33.5':
-    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==, tarball: https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
   '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==, tarball: https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.33.5':
-    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==, tarball: https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==, tarball: https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-arm64@1.0.4':
-    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==, tarball: https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz}
     cpu: [arm64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==, tarball: https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz}
     cpu: [arm64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.0.4':
-    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==, tarball: https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz}
     cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==, tarball: https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz}
     cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-linux-arm64@1.0.4':
-    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
-    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
-    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
-    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
-    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
-    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==, tarball: https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==, tarball: https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
-    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==, tarball: https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==, tarball: https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==, tarball: https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==, tarball: https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
-    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==, tarball: https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==, tarball: https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
-    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==, tarball: https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==, tarball: https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
-    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==, tarball: https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==, tarball: https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
-    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==, tarball: https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==, tarball: https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
-    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==, tarball: https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
   '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==, tarball: https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
   '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==, tarball: https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [win32]
 
   '@img/sharp-win32-ia32@0.33.5':
-    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==, tarball: https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
   '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==, tarball: https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
   '@img/sharp-win32-x64@0.33.5':
-    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==, tarball: https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
 
   '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==, tarball: https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
@@ -832,122 +864,131 @@ packages:
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@napi-rs/canvas-android-arm64@0.1.97':
-    resolution: {integrity: sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==}
+    resolution: {integrity: sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==, tarball: https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.97.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
 
   '@napi-rs/canvas-darwin-arm64@0.1.97':
-    resolution: {integrity: sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw==}
+    resolution: {integrity: sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw==, tarball: https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.97.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
   '@napi-rs/canvas-darwin-x64@0.1.97':
-    resolution: {integrity: sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA==}
+    resolution: {integrity: sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA==, tarball: https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.97.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
   '@napi-rs/canvas-linux-arm-gnueabihf@0.1.97':
-    resolution: {integrity: sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw==}
+    resolution: {integrity: sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw==, tarball: https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.97.tgz}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
   '@napi-rs/canvas-linux-arm64-gnu@0.1.97':
-    resolution: {integrity: sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w==}
+    resolution: {integrity: sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w==, tarball: https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.97.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.97':
-    resolution: {integrity: sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==}
+    resolution: {integrity: sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==, tarball: https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.97.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.97':
-    resolution: {integrity: sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==}
+    resolution: {integrity: sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==, tarball: https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.97.tgz}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.97':
-    resolution: {integrity: sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==}
+    resolution: {integrity: sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==, tarball: https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.97.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.97':
-    resolution: {integrity: sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==}
+    resolution: {integrity: sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==, tarball: https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.97.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.97':
-    resolution: {integrity: sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==}
+    resolution: {integrity: sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==, tarball: https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.97.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
   '@napi-rs/canvas-win32-x64-msvc@0.1.97':
-    resolution: {integrity: sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ==}
+    resolution: {integrity: sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ==, tarball: https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.97.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
   '@napi-rs/canvas@0.1.97':
-    resolution: {integrity: sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==}
+    resolution: {integrity: sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==, tarball: https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.97.tgz}
     engines: {node: '>= 10'}
 
   '@next/env@16.2.0':
     resolution: {integrity: sha512-OZIbODWWAi0epQRCRjNe1VO45LOFBzgiyqmTLzIqWq6u1wrxKnAyz1HH6tgY/Mc81YzIjRPoYsPAEr4QV4l9TA==}
 
   '@next/swc-darwin-arm64@16.2.0':
-    resolution: {integrity: sha512-/JZsqKzKt01IFoiLLAzlNqys7qk2F3JkcUhj50zuRhKDQkZNOz9E5N6wAQWprXdsvjRP4lTFj+/+36NSv5AwhQ==}
+    resolution: {integrity: sha512-/JZsqKzKt01IFoiLLAzlNqys7qk2F3JkcUhj50zuRhKDQkZNOz9E5N6wAQWprXdsvjRP4lTFj+/+36NSv5AwhQ==, tarball: https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.0.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
   '@next/swc-darwin-x64@16.2.0':
-    resolution: {integrity: sha512-/hV8erWq4SNlVgglUiW5UmQ5Hwy5EW/AbbXlJCn6zkfKxTy/E/U3V8U1Ocm2YCTUoFgQdoMxRyRMOW5jYy4ygg==}
+    resolution: {integrity: sha512-/hV8erWq4SNlVgglUiW5UmQ5Hwy5EW/AbbXlJCn6zkfKxTy/E/U3V8U1Ocm2YCTUoFgQdoMxRyRMOW5jYy4ygg==, tarball: https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.0.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
   '@next/swc-linux-arm64-gnu@16.2.0':
-    resolution: {integrity: sha512-GkjL/Q7MWOwqWR9zoxu1TIHzkOI2l2BHCf7FzeQG87zPgs+6WDh+oC9Sw9ARuuL/FUk6JNCgKRkA6rEQYadUaw==}
+    resolution: {integrity: sha512-GkjL/Q7MWOwqWR9zoxu1TIHzkOI2l2BHCf7FzeQG87zPgs+6WDh+oC9Sw9ARuuL/FUk6JNCgKRkA6rEQYadUaw==, tarball: https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.0.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.0':
-    resolution: {integrity: sha512-1ffhC6KY5qWLg5miMlKJp3dZbXelEfjuXt1qcp5WzSCQy36CV3y+JT7OC1WSFKizGQCDOcQbfkH/IjZP3cdRNA==}
+    resolution: {integrity: sha512-1ffhC6KY5qWLg5miMlKJp3dZbXelEfjuXt1qcp5WzSCQy36CV3y+JT7OC1WSFKizGQCDOcQbfkH/IjZP3cdRNA==, tarball: https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.0.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.0':
-    resolution: {integrity: sha512-FmbDcZQ8yJRq93EJSL6xaE0KK/Rslraf8fj1uViGxg7K4CKBCRYSubILJPEhjSgZurpcPQq12QNOJQ0DRJl6Hg==}
+    resolution: {integrity: sha512-FmbDcZQ8yJRq93EJSL6xaE0KK/Rslraf8fj1uViGxg7K4CKBCRYSubILJPEhjSgZurpcPQq12QNOJQ0DRJl6Hg==, tarball: https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.0.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.0':
-    resolution: {integrity: sha512-HzjIHVkmGAwRbh/vzvoBWWEbb8BBZPxBvVbDQDvzHSf3D8RP/4vjw7MNLDXFF9Q1WEzeQyEj2zdxBtVAHu5Oyw==}
+    resolution: {integrity: sha512-HzjIHVkmGAwRbh/vzvoBWWEbb8BBZPxBvVbDQDvzHSf3D8RP/4vjw7MNLDXFF9Q1WEzeQyEj2zdxBtVAHu5Oyw==, tarball: https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.0.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.0':
-    resolution: {integrity: sha512-UMiFNQf5H7+1ZsZPxEsA064WEuFbRNq/kEXyepbCnSErp4f5iut75dBA8UeerFIG3vDaQNOfCpevnERPp2V+nA==}
+    resolution: {integrity: sha512-UMiFNQf5H7+1ZsZPxEsA064WEuFbRNq/kEXyepbCnSErp4f5iut75dBA8UeerFIG3vDaQNOfCpevnERPp2V+nA==, tarball: https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.0.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
   '@next/swc-win32-x64-msvc@16.2.0':
-    resolution: {integrity: sha512-DRrNJKW+/eimrZgdhVN1uvkN1OI4j6Lpefwr44jKQ0YQzztlmOBUUzHuV5GxOMPK3nmodAYElUVCY8ZXo/IWeA==}
+    resolution: {integrity: sha512-DRrNJKW+/eimrZgdhVN1uvkN1OI4j6Lpefwr44jKQ0YQzztlmOBUUzHuV5GxOMPK3nmodAYElUVCY8ZXo/IWeA==, tarball: https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.0.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1518,61 +1559,65 @@ packages:
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
 
   '@tailwindcss/oxide-android-arm64@4.2.2':
-    resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==}
+    resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
 
   '@tailwindcss/oxide-darwin-arm64@4.2.2':
-    resolution: {integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==}
+    resolution: {integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
   '@tailwindcss/oxide-darwin-x64@4.2.2':
-    resolution: {integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==}
+    resolution: {integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
   '@tailwindcss/oxide-freebsd-x64@4.2.2':
-    resolution: {integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==}
+    resolution: {integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [freebsd]
 
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
-    resolution: {integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==}
+    resolution: {integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
-    resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==}
+    resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
-    resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
+    resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
-    resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
+    resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
-    resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
+    resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
-    resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
+    resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
@@ -1584,13 +1629,13 @@ packages:
       - tslib
 
   '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
-    resolution: {integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==}
+    resolution: {integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
 
   '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
-    resolution: {integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==}
+    resolution: {integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
@@ -1656,7 +1701,7 @@ packages:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==, tarball: https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1705,7 +1750,7 @@ packages:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
 
   convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==, tarball: https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -1726,13 +1771,13 @@ packages:
       date-fns: ^3.0.0 || ^4.0.0
 
   date-fns@4.1.0:
-    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==, tarball: https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz}
 
   dayjs@1.11.20:
     resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==, tarball: https://registry.npmjs.org/debug/-/debug-4.4.3.tgz}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -1756,7 +1801,7 @@ packages:
     engines: {node: '>= 0.4'}
 
   electron-to-chromium@1.5.321:
-    resolution: {integrity: sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==}
+    resolution: {integrity: sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==, tarball: https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
@@ -1779,7 +1824,7 @@ packages:
     engines: {node: '>= 0.4'}
 
   escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==, tarball: https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz}
     engines: {node: '>=6'}
 
   events@3.3.0:
@@ -1807,7 +1852,7 @@ packages:
     engines: {node: '>= 6'}
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
@@ -1815,7 +1860,7 @@ packages:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==, tarball: https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz}
     engines: {node: '>=6.9.0'}
 
   get-intrinsic@1.3.0:
@@ -1905,7 +1950,7 @@ packages:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==, tarball: https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz}
     engines: {node: '>=6'}
     hasBin: true
 
@@ -1913,7 +1958,7 @@ packages:
     resolution: {integrity: sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==}
 
   json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==, tarball: https://registry.npmjs.org/json5/-/json5-2.2.3.tgz}
     engines: {node: '>=6'}
     hasBin: true
 
@@ -1921,52 +1966,52 @@ packages:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
   lefthook-darwin-arm64@1.13.6:
-    resolution: {integrity: sha512-m6Lb77VGc84/Qo21Lhq576pEvcgFCnvloEiP02HbAHcIXD0RTLy9u2yAInrixqZeaz13HYtdDaI7OBYAAdVt8A==}
+    resolution: {integrity: sha512-m6Lb77VGc84/Qo21Lhq576pEvcgFCnvloEiP02HbAHcIXD0RTLy9u2yAInrixqZeaz13HYtdDaI7OBYAAdVt8A==, tarball: https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.13.6.tgz}
     cpu: [arm64]
     os: [darwin]
 
   lefthook-darwin-x64@1.13.6:
-    resolution: {integrity: sha512-CoRpdzanu9RK3oXR1vbEJA5LN7iB+c7hP+sONeQJzoOXuq4PNKVtEaN84Gl1BrVtCNLHWFAvCQaZPPiiXSy8qg==}
+    resolution: {integrity: sha512-CoRpdzanu9RK3oXR1vbEJA5LN7iB+c7hP+sONeQJzoOXuq4PNKVtEaN84Gl1BrVtCNLHWFAvCQaZPPiiXSy8qg==, tarball: https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.13.6.tgz}
     cpu: [x64]
     os: [darwin]
 
   lefthook-freebsd-arm64@1.13.6:
-    resolution: {integrity: sha512-X4A7yfvAJ68CoHTqP+XvQzdKbyd935sYy0bQT6Ajz7FL1g7hFiro8dqHSdPdkwei9hs8hXeV7feyTXbYmfjKQQ==}
+    resolution: {integrity: sha512-X4A7yfvAJ68CoHTqP+XvQzdKbyd935sYy0bQT6Ajz7FL1g7hFiro8dqHSdPdkwei9hs8hXeV7feyTXbYmfjKQQ==, tarball: https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.13.6.tgz}
     cpu: [arm64]
     os: [freebsd]
 
   lefthook-freebsd-x64@1.13.6:
-    resolution: {integrity: sha512-ai2m+Sj2kGdY46USfBrCqLKe9GYhzeq01nuyDYCrdGISePeZ6udOlD1k3lQKJGQCHb0bRz4St0r5nKDSh1x/2A==}
+    resolution: {integrity: sha512-ai2m+Sj2kGdY46USfBrCqLKe9GYhzeq01nuyDYCrdGISePeZ6udOlD1k3lQKJGQCHb0bRz4St0r5nKDSh1x/2A==, tarball: https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.13.6.tgz}
     cpu: [x64]
     os: [freebsd]
 
   lefthook-linux-arm64@1.13.6:
-    resolution: {integrity: sha512-cbo4Wtdq81GTABvikLORJsAWPKAJXE8Q5RXsICFUVznh5PHigS9dFW/4NXywo0+jfFPCT6SYds2zz4tCx6DA0Q==}
+    resolution: {integrity: sha512-cbo4Wtdq81GTABvikLORJsAWPKAJXE8Q5RXsICFUVznh5PHigS9dFW/4NXywo0+jfFPCT6SYds2zz4tCx6DA0Q==, tarball: https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.13.6.tgz}
     cpu: [arm64]
     os: [linux]
 
   lefthook-linux-x64@1.13.6:
-    resolution: {integrity: sha512-uJl9vjCIIBTBvMZkemxCE+3zrZHlRO7Oc+nZJ+o9Oea3fu+W82jwX7a7clw8jqNfaeBS+8+ZEQgiMHWCloTsGw==}
+    resolution: {integrity: sha512-uJl9vjCIIBTBvMZkemxCE+3zrZHlRO7Oc+nZJ+o9Oea3fu+W82jwX7a7clw8jqNfaeBS+8+ZEQgiMHWCloTsGw==, tarball: https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.13.6.tgz}
     cpu: [x64]
     os: [linux]
 
   lefthook-openbsd-arm64@1.13.6:
-    resolution: {integrity: sha512-7r153dxrNRQ9ytRs2PmGKKkYdvZYFPre7My7XToSTiRu5jNCq++++eAKVkoyWPduk97dGIA+YWiEr5Noe0TK2A==}
+    resolution: {integrity: sha512-7r153dxrNRQ9ytRs2PmGKKkYdvZYFPre7My7XToSTiRu5jNCq++++eAKVkoyWPduk97dGIA+YWiEr5Noe0TK2A==, tarball: https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.13.6.tgz}
     cpu: [arm64]
     os: [openbsd]
 
   lefthook-openbsd-x64@1.13.6:
-    resolution: {integrity: sha512-Z+UhLlcg1xrXOidK3aLLpgH7KrwNyWYE3yb7ITYnzJSEV8qXnePtVu8lvMBHs/myzemjBzeIr/U/+ipjclR06g==}
+    resolution: {integrity: sha512-Z+UhLlcg1xrXOidK3aLLpgH7KrwNyWYE3yb7ITYnzJSEV8qXnePtVu8lvMBHs/myzemjBzeIr/U/+ipjclR06g==, tarball: https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.13.6.tgz}
     cpu: [x64]
     os: [openbsd]
 
   lefthook-windows-arm64@1.13.6:
-    resolution: {integrity: sha512-Uxef6qoDxCmUNQwk8eBvddYJKSBFglfwAY9Y9+NnnmiHpWTjjYiObE9gT2mvGVpEgZRJVAatBXc+Ha5oDD/OgQ==}
+    resolution: {integrity: sha512-Uxef6qoDxCmUNQwk8eBvddYJKSBFglfwAY9Y9+NnnmiHpWTjjYiObE9gT2mvGVpEgZRJVAatBXc+Ha5oDD/OgQ==, tarball: https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.13.6.tgz}
     cpu: [arm64]
     os: [win32]
 
   lefthook-windows-x64@1.13.6:
-    resolution: {integrity: sha512-mOZoM3FQh3o08M8PQ/b3IYuL5oo36D9ehczIw1dAgp1Ly+Tr4fJ96A+4SEJrQuYeRD4mex9bR7Ps56I73sBSZA==}
+    resolution: {integrity: sha512-mOZoM3FQh3o08M8PQ/b3IYuL5oo36D9ehczIw1dAgp1Ly+Tr4fJ96A+4SEJrQuYeRD4mex9bR7Ps56I73sBSZA==, tarball: https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.13.6.tgz}
     cpu: [x64]
     os: [win32]
 
@@ -1978,67 +2023,71 @@ packages:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==, tarball: https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
   lightningcss-darwin-arm64@1.32.0:
-    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==, tarball: https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==, tarball: https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
 
   lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==, tarball: https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==, tarball: https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
   lightningcss-linux-arm64-gnu@1.32.0:
-    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==, tarball: https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
-    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==, tarball: https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
-    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==, tarball: https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
-    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==, tarball: https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
-    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==, tarball: https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.32.0:
-    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==, tarball: https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
@@ -2052,7 +2101,7 @@ packages:
     hasBin: true
 
   lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==, tarball: https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz}
 
   lucide-react@0.525.0:
     resolution: {integrity: sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==}
@@ -2078,7 +2127,7 @@ packages:
     engines: {node: '>= 0.6'}
 
   ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==, tarball: https://registry.npmjs.org/ms/-/ms-2.1.3.tgz}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -2129,7 +2178,7 @@ packages:
         optional: true
 
   node-releases@2.0.36:
-    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==, tarball: https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz}
 
   oauth4webapi@3.8.5:
     resolution: {integrity: sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==}
@@ -2473,7 +2522,7 @@ packages:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
   semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==, tarball: https://registry.npmjs.org/semver/-/semver-6.3.1.tgz}
     hasBin: true
 
   semver@7.7.4:
@@ -2489,7 +2538,7 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==, tarball: https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   simple-swizzle@0.2.4:
@@ -2570,7 +2619,7 @@ packages:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==, tarball: https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -2599,7 +2648,7 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==, tarball: https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}

--- a/src/_types/slide-preview.ts
+++ b/src/_types/slide-preview.ts
@@ -29,7 +29,13 @@ export type AnimationFrame = {
 
 export type AnimationSequence = AnimationFrame[];
 
+export type RawSignageItem = {
+  frameName: string; // EIA frame name (e.g. "5"), used for cross-part global resolution
+  duration: number; // ms
+};
+
 export type DecodeResult = {
   frames: SlideFrame[];
   animation: AnimationSequence | null;
+  rawSignageItems?: RawSignageItem[]; // present for EIA files; used by decodeSlides for global ordering
 };

--- a/src/_types/slide-preview.ts
+++ b/src/_types/slide-preview.ts
@@ -21,3 +21,15 @@ export type SlideFrameMeta = {
   height: number;
   hasAnimations?: boolean;
 };
+
+export type AnimationFrame = {
+  frameIndex: number;
+  duration: number; // ms
+};
+
+export type AnimationSequence = AnimationFrame[];
+
+export type DecodeResult = {
+  frames: SlideFrame[];
+  animation: AnimationSequence | null;
+};

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -140,7 +140,10 @@ export const GooglePicker = () => {
   );
 };
 
-const slide2canvas = async (slideId: string): Promise<SelectedFile[]> => {
+const slide2canvas = async (
+  slideId: string,
+  signal?: AbortSignal,
+): Promise<SelectedFile[]> => {
   const [{ canvases, buffer }, metadata] = await Promise.all([
     (async () => {
       const buffer = await fetchSlideAsPdf(slideId);
@@ -183,6 +186,7 @@ const slide2canvas = async (slideId: string): Promise<SelectedFile[]> => {
       metadata.pageSize,
       { width: canvas.width, height: canvas.height },
       canvas,
+      signal,
     );
     results.push({
       id: crypto.randomUUID(),

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -18,7 +18,7 @@ import { extractGifAnimations } from "@/lib/google/extractGifAnimations";
 import { LoadingOutlined } from "@ant-design/icons";
 import { Button, Flex, Spin, message } from "antd";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { TbBrandGoogleDrive } from "react-icons/tb";
 
 export const GooglePicker = () => {
@@ -28,6 +28,13 @@ export const GooglePicker = () => {
   const setFiles = useSetAtom(SelectedFilesAtom);
   const [validating, setValidating] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
 
   const showPicker = async (__token = token) => {
     const _token =
@@ -64,6 +71,9 @@ export const GooglePicker = () => {
   const onFilePicked = async (data: GoogleFilePickerCallbackData) => {
     if (data.action !== "picked" || !data.docs) return;
     const file = data.docs[0];
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
     setIsLoading(true);
     try {
       if (file.mimeType === "application/pdf") {
@@ -78,7 +88,7 @@ export const GooglePicker = () => {
         setFiles((pv) => [...pv, ...selectedFiles]);
       }
       if (file.mimeType === "application/vnd.google-apps.presentation") {
-        const files = await slide2canvas(file.id);
+        const files = await slide2canvas(file.id, controller.signal);
         setFiles((pv) => [...pv, ...files]);
       }
       if (file.mimeType?.startsWith("image/")) {
@@ -90,6 +100,7 @@ export const GooglePicker = () => {
         setFiles((pv) => [...pv, ...canvas]);
       }
     } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
       console.error(e);
       void messageApi.error(
         e instanceof Error
@@ -97,7 +108,9 @@ export const GooglePicker = () => {
           : "Failed to load file from Google Drive",
       );
     } finally {
-      setIsLoading(false);
+      if (abortControllerRef.current === controller) {
+        setIsLoading(false);
+      }
     }
   };
 
@@ -140,7 +153,10 @@ export const GooglePicker = () => {
   );
 };
 
-const slide2canvas = async (slideId: string): Promise<SelectedFile[]> => {
+const slide2canvas = async (
+  slideId: string,
+  signal?: AbortSignal,
+): Promise<SelectedFile[]> => {
   const [{ canvases, buffer }, metadata] = await Promise.all([
     (async () => {
       const buffer = await fetchSlideAsPdf(slideId);
@@ -183,6 +199,7 @@ const slide2canvas = async (slideId: string): Promise<SelectedFile[]> => {
       metadata.pageSize,
       { width: canvas.width, height: canvas.height },
       canvas,
+      signal,
     );
     results.push({
       id: crypto.randomUUID(),

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -140,10 +140,7 @@ export const GooglePicker = () => {
   );
 };
 
-const slide2canvas = async (
-  slideId: string,
-  signal?: AbortSignal,
-): Promise<SelectedFile[]> => {
+const slide2canvas = async (slideId: string): Promise<SelectedFile[]> => {
   const [{ canvases, buffer }, metadata] = await Promise.all([
     (async () => {
       const buffer = await fetchSlideAsPdf(slideId);
@@ -186,7 +183,6 @@ const slide2canvas = async (
       metadata.pageSize,
       { width: canvas.width, height: canvas.height },
       canvas,
-      signal,
     );
     results.push({
       id: crypto.randomUUID(),

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -75,6 +75,11 @@ export const GooglePicker = () => {
     const controller = new AbortController();
     abortControllerRef.current = controller;
     setIsLoading(true);
+    // True iff this invocation's controller is still the active one.
+    // Guards against appending stale results when a newer pick has aborted us
+    // while async work (which may not honor the signal) was still in flight.
+    const isStillActive = () =>
+      abortControllerRef.current === controller && !controller.signal.aborted;
     try {
       if (file.mimeType === "application/pdf") {
         const fileObj = new File(
@@ -85,10 +90,12 @@ export const GooglePicker = () => {
           },
         );
         const selectedFiles = await file2selectedFiles(fileObj);
+        if (!isStillActive()) return;
         setFiles((pv) => [...pv, ...selectedFiles]);
       }
       if (file.mimeType === "application/vnd.google-apps.presentation") {
         const files = await slide2canvas(file.id, controller.signal);
+        if (!isStillActive()) return;
         setFiles((pv) => [...pv, ...files]);
       }
       if (file.mimeType?.startsWith("image/")) {
@@ -97,6 +104,7 @@ export const GooglePicker = () => {
           type: file.mimeType,
         });
         const canvas = await file2selectedFiles(fileObject);
+        if (!isStillActive()) return;
         setFiles((pv) => [...pv, ...canvas]);
       }
     } catch (e) {
@@ -153,20 +161,49 @@ export const GooglePicker = () => {
   );
 };
 
+// Wrap a non-cancellable promise so it rejects as soon as `signal` aborts.
+// Underlying work (e.g. gapi calls) keeps running in the background, but
+// awaiters bail out immediately rather than waiting for it to finish.
+const raceWithAbort = <T,>(p: Promise<T>, signal?: AbortSignal): Promise<T> => {
+  if (!signal) return p;
+  // signal.reason is undefined per spec when abort() is called without an
+  // argument; fall back so `onFilePicked`'s `e instanceof DOMException` catch
+  // still recognizes the rejection.
+  const abortReason = () =>
+    signal.reason ?? new DOMException("Aborted", "AbortError");
+  if (signal.aborted) return Promise.reject(abortReason());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(abortReason());
+    signal.addEventListener("abort", onAbort, { once: true });
+    p.then(
+      (v) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(v);
+      },
+      (e) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(e);
+      },
+    );
+  });
+};
+
 const slide2canvas = async (
   slideId: string,
   signal?: AbortSignal,
 ): Promise<SelectedFile[]> => {
   const [{ canvases, buffer }, metadata] = await Promise.all([
     (async () => {
-      const buffer = await fetchSlideAsPdf(slideId);
+      const buffer = await raceWithAbort(fetchSlideAsPdf(slideId), signal);
+      signal?.throwIfAborted();
       return {
-        canvases: await pdf2canvases(buffer),
+        canvases: await raceWithAbort(pdf2canvases(buffer), signal),
         buffer,
       };
     })(),
-    fetchSlideMetadata(slideId),
+    raceWithAbort(fetchSlideMetadata(slideId), signal),
   ]);
+  signal?.throwIfAborted();
 
   const file = new File([buffer], metadata.title, {
     type: "application/pdf",
@@ -193,6 +230,7 @@ const slide2canvas = async (
   // across 30 slides would multiply that cap by the slide count).
   const results: SelectedFile[] = [];
   for (const [outputIndex, slide] of filteredSlides.entries()) {
+    signal?.throwIfAborted();
     const { canvas, index, speakerNote, pageElements } = slide;
     const animations = await extractGifAnimations(
       pageElements,

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -58,13 +58,10 @@ export const GooglePicker = () => {
       await showPicker(null);
       return;
     }
-    void showFilePicker(_token, (data) => onFilePicked(data, _token));
+    void showFilePicker(_token, (data) => onFilePicked(data));
   };
 
-  const onFilePicked = async (
-    data: GoogleFilePickerCallbackData,
-    currentToken: string,
-  ) => {
+  const onFilePicked = async (data: GoogleFilePickerCallbackData) => {
     if (data.action !== "picked" || !data.docs) return;
     const file = data.docs[0];
     setIsLoading(true);
@@ -81,7 +78,7 @@ export const GooglePicker = () => {
         setFiles((pv) => [...pv, ...selectedFiles]);
       }
       if (file.mimeType === "application/vnd.google-apps.presentation") {
-        const files = await slide2canvas(file.id, currentToken);
+        const files = await slide2canvas(file.id);
         setFiles((pv) => [...pv, ...files]);
       }
       if (file.mimeType?.startsWith("image/")) {
@@ -143,10 +140,7 @@ export const GooglePicker = () => {
   );
 };
 
-const slide2canvas = async (
-  slideId: string,
-  token: string,
-): Promise<SelectedFile[]> => {
+const slide2canvas = async (slideId: string): Promise<SelectedFile[]> => {
   const [{ canvases, buffer }, metadata] = await Promise.all([
     (async () => {
       const buffer = await fetchSlideAsPdf(slideId);
@@ -186,7 +180,6 @@ const slide2canvas = async (
         metadata.pageSize,
         { width: canvas.width, height: canvas.height },
         canvas,
-        token,
       );
       return {
         id: crypto.randomUUID(),

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -172,16 +172,22 @@ const slide2canvas = async (slideId: string): Promise<SelectedFile[]> => {
     }))
     .filter(({ isSkipped }) => !isSkipped);
 
-  const results: SelectedFile[] = await Promise.all(
-    filteredSlides.map(async (slide, outputIndex) => {
+  // Process slides sequentially so the per-slide GIF_FETCH_CONCURRENCY cap in
+  // extractGifAnimations actually bounds total proxy load (parallel Promise.all
+  // across 30 slides would multiply that cap by the slide count).
+  const controller = new AbortController();
+  const results: SelectedFile[] = [];
+  try {
+    for (const [outputIndex, slide] of filteredSlides.entries()) {
       const { canvas, index, speakerNote, pageElements } = slide;
       const animations = await extractGifAnimations(
         pageElements,
         metadata.pageSize,
         { width: canvas.width, height: canvas.height },
         canvas,
+        controller.signal,
       );
-      return {
+      results.push({
         id: crypto.randomUUID(),
         fileName: `${metadata.title}-${outputIndex + 1}`,
         canvas,
@@ -193,8 +199,11 @@ const slide2canvas = async (slideId: string): Promise<SelectedFile[]> => {
           index,
           scale: 1,
         },
-      };
-    }),
-  );
+      });
+    }
+  } catch (e) {
+    controller.abort();
+    throw e;
+  }
   return results;
 };

--- a/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -175,35 +175,28 @@ const slide2canvas = async (slideId: string): Promise<SelectedFile[]> => {
   // Process slides sequentially so the per-slide GIF_FETCH_CONCURRENCY cap in
   // extractGifAnimations actually bounds total proxy load (parallel Promise.all
   // across 30 slides would multiply that cap by the slide count).
-  const controller = new AbortController();
   const results: SelectedFile[] = [];
-  try {
-    for (const [outputIndex, slide] of filteredSlides.entries()) {
-      const { canvas, index, speakerNote, pageElements } = slide;
-      const animations = await extractGifAnimations(
-        pageElements,
-        metadata.pageSize,
-        { width: canvas.width, height: canvas.height },
-        canvas,
-        controller.signal,
-      );
-      results.push({
-        id: crypto.randomUUID(),
-        fileName: `${metadata.title}-${outputIndex + 1}`,
-        canvas,
-        note: speakerNote,
-        animations: animations.length > 0 ? animations : undefined,
-        metadata: {
-          fileType: "pdf" as const,
-          file,
-          index,
-          scale: 1,
-        },
-      });
-    }
-  } catch (e) {
-    controller.abort();
-    throw e;
+  for (const [outputIndex, slide] of filteredSlides.entries()) {
+    const { canvas, index, speakerNote, pageElements } = slide;
+    const animations = await extractGifAnimations(
+      pageElements,
+      metadata.pageSize,
+      { width: canvas.width, height: canvas.height },
+      canvas,
+    );
+    results.push({
+      id: crypto.randomUUID(),
+      fileName: `${metadata.title}-${outputIndex + 1}`,
+      canvas,
+      note: speakerNote,
+      animations: animations.length > 0 ? animations : undefined,
+      metadata: {
+        fileType: "pdf" as const,
+        file,
+        index,
+        scale: 1,
+      },
+    });
   }
   return results;
 };

--- a/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
+++ b/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
@@ -402,6 +402,7 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
   }, []);
 
   const startAnimation = useCallback(() => {
+    stopAnimation(); // clear any orphaned timer before starting a new chain
     const anim = animationRef.current;
     if (!anim || anim.length === 0) return;
     // Sync start position to the currently displayed slide via ref (avoids side effects in state updater)
@@ -413,7 +414,7 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
     setSelectedIndex(anim[startPos].frameIndex);
     setIsPlaying(true);
     scheduleNext(startPos);
-  }, [scheduleNext]);
+  }, [scheduleNext, stopAnimation]);
 
   // Stop animation and reset position when the animation sequence changes
   // biome-ignore lint/correctness/useExhaustiveDependencies: animation change triggers position reset

--- a/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
+++ b/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
@@ -1,9 +1,21 @@
 "use client";
-import type { SlideFrameMeta } from "@/_types/slide-preview";
+import type { AnimationSequence, SlideFrameMeta } from "@/_types/slide-preview";
 import { decodeSlides } from "@/lib/slidePreview/decodeSlides";
 import { Button, Spin } from "antd";
-import { type FC, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { TbChevronLeft, TbChevronRight } from "react-icons/tb";
+import {
+  type FC,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  TbChevronLeft,
+  TbChevronRight,
+  TbPlayerPause,
+  TbPlayerPlay,
+} from "react-icons/tb";
 
 type DecodedAnimation = {
   x: number;
@@ -210,17 +222,66 @@ const MainView: FC<{
   bitmapMap: { current: Map<number, ImageBitmap> };
   animationMap: { current: Map<number, DecodedAnimation[]> };
   selectedIndex: number;
+  animation: AnimationSequence | null;
   onPrevious: () => void;
   onNext: () => void;
+  onSelectFrame: (index: number) => void;
 }> = ({
   frames,
   bitmapMap,
   animationMap,
   selectedIndex,
+  animation,
   onPrevious,
   onNext,
+  onSelectFrame,
 }) => {
   const selectedFrame = frames[selectedIndex];
+  const [isPlaying, setIsPlaying] = useState(false);
+  const animationPosRef = useRef(0);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const stopAnimation = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setIsPlaying(false);
+  }, []);
+
+  const scheduleNext = useCallback(
+    (pos: number) => {
+      if (!animation) return;
+      const current = animation[pos];
+      timeoutRef.current = setTimeout(() => {
+        const nextPos = (pos + 1) % animation.length;
+        animationPosRef.current = nextPos;
+        onSelectFrame(animation[nextPos].frameIndex);
+        scheduleNext(nextPos);
+      }, current.duration);
+    },
+    [animation, onSelectFrame],
+  );
+
+  const startAnimation = useCallback(() => {
+    if (!animation || animation.length === 0) return;
+    setIsPlaying(true);
+    const startPos = animationPosRef.current;
+    onSelectFrame(animation[startPos].frameIndex);
+    scheduleNext(startPos);
+  }, [animation, onSelectFrame, scheduleNext]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: animation change triggers position reset
+  useEffect(() => {
+    stopAnimation();
+    animationPosRef.current = 0;
+  }, [animation, stopAnimation]);
 
   return (
     <div className="flex flex-col gap-4 flex-1 md:w-3/4 md:px-4 md:py-2">
@@ -241,9 +302,25 @@ const MainView: FC<{
           disabled={selectedIndex <= 0}
         />
 
-        <div className="text-sm text-center text-primary">
-          スライド {selectedIndex + 1} / {frames.length}
+        <div className="flex items-center gap-2">
+          <div className="text-sm text-center text-primary">
+            スライド {selectedIndex + 1} / {frames.length}
+          </div>
+          {animation && (
+            <Button
+              type="default"
+              icon={
+                isPlaying ? (
+                  <TbPlayerPause size={16} />
+                ) : (
+                  <TbPlayerPlay size={16} />
+                )
+              }
+              onClick={isPlaying ? stopAnimation : startAnimation}
+            />
+          )}
         </div>
+
         {/* Next Button */}
         <Button
           type="primary"
@@ -261,6 +338,7 @@ const SlidePreviewContainer: FC<{
   bitmapMap: { current: Map<number, ImageBitmap> };
   animationMap: { current: Map<number, DecodedAnimation[]> };
   selectedIndex: number;
+  animation: AnimationSequence | null;
   onSelectFrame: (index: number) => void;
   onPrevious: () => void;
   onNext: () => void;
@@ -269,6 +347,7 @@ const SlidePreviewContainer: FC<{
   bitmapMap,
   animationMap,
   selectedIndex,
+  animation,
   onSelectFrame,
   onPrevious,
   onNext,
@@ -286,8 +365,10 @@ const SlidePreviewContainer: FC<{
         bitmapMap={bitmapMap}
         animationMap={animationMap}
         selectedIndex={selectedIndex}
+        animation={animation}
         onPrevious={onPrevious}
         onNext={onNext}
+        onSelectFrame={onSelectFrame}
       />
     </div>
   );
@@ -309,6 +390,7 @@ const imageDataToBitmap = async (data: ImageData): Promise<ImageBitmap> => {
 
 export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
   const [frames, setFrames] = useState<SlideFrameMeta[] | null>(null);
+  const [animation, setAnimation] = useState<AnimationSequence | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const bitmapMap = useRef<Map<number, ImageBitmap>>(new Map());
@@ -316,6 +398,7 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
 
   useEffect(() => {
     setFrames(null);
+    setAnimation(null);
     setError(null);
     setSelectedIndex(0);
     for (const bitmap of bitmapMap.current.values()) bitmap.close();
@@ -336,9 +419,10 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
           const map = new Map<number, ImageBitmap>();
           const meta: SlideFrameMeta[] = [];
           nextMap = map;
+          const remainingFrames = [...result.frames];
 
-          while (result.length > 0) {
-            const f = result.shift();
+          while (remainingFrames.length > 0) {
+            const f = remainingFrames.shift();
             if (!f) break;
             if (controller.signal.aborted) break;
 
@@ -379,6 +463,7 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
             animationMap.current = nextAnimMap;
             nextMap = null;
             setFrames(meta);
+            setAnimation(result.animation);
           }
         }
       } catch (e: unknown) {
@@ -445,6 +530,7 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
       bitmapMap={bitmapMap}
       animationMap={animationMap}
       selectedIndex={selectedIndex}
+      animation={animation}
       onSelectFrame={setSelectedIndex}
       onPrevious={handlePrevious}
       onNext={handleNext}

--- a/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
+++ b/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
@@ -378,10 +378,17 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
   const animationPosRef = useRef(0);
   const selectedIndexRef = useRef(0);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const framesRef = useRef<SlideFrameMeta[] | null>(null);
 
-  // Keep refs in sync so callbacks always see the latest values without stale closures
-  animationRef.current = animation;
-  selectedIndexRef.current = selectedIndex;
+  // Keep refs in sync so callbacks always see the latest values without stale closures.
+  // useLayoutEffect runs after every commit, before paint, so refs are updated before
+  // any timer callback or event handler fires — avoiding the concurrent-mode hazard of
+  // mutating refs directly in the render body.
+  useLayoutEffect(() => {
+    animationRef.current = animation;
+    selectedIndexRef.current = selectedIndex;
+    framesRef.current = frames;
+  }, [animation, selectedIndex, frames]);
 
   const stopAnimation = useCallback(() => {
     if (timeoutRef.current !== null) {
@@ -391,6 +398,10 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
     setIsPlaying(false);
   }, []);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: empty deps intentional —
+  // scheduleNext must have a stable identity so the recursive chain inside the timeout
+  // callback always refers to the same function instance. All mutable state is accessed
+  // through refs (animationRef), not captured variables.
   const scheduleNext = useCallback((pos: number) => {
     const anim = animationRef.current;
     if (!anim) return;
@@ -400,9 +411,11 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
         ? current.duration
         : 100;
     timeoutRef.current = setTimeout(() => {
-      const nextPos = (pos + 1) % anim.length;
+      const latestAnim = animationRef.current;
+      if (!latestAnim) return;
+      const nextPos = (pos + 1) % latestAnim.length;
       animationPosRef.current = nextPos;
-      setSelectedIndex(anim[nextPos].frameIndex);
+      setSelectedIndex(latestAnim[nextPos].frameIndex);
       scheduleNext(nextPos);
     }, duration);
   }, []);
@@ -443,8 +456,10 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
 
   const handleNext = useCallback(() => {
     stopAnimation();
-    setSelectedIndex((prev) => Math.min((frames?.length ?? 1) - 1, prev + 1));
-  }, [stopAnimation, frames]);
+    setSelectedIndex((prev) =>
+      Math.min((framesRef.current?.length ?? 1) - 1, prev + 1),
+    );
+  }, [stopAnimation]);
 
   const handleSelectFrame = useCallback(
     (index: number) => {
@@ -455,6 +470,7 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
   );
 
   useEffect(() => {
+    stopAnimation();
     setFrames(null);
     setAnimation(null);
     setError(null);
@@ -552,7 +568,7 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
       }
       animationMap.current.clear();
     };
-  }, [urls]);
+  }, [urls, stopAnimation]);
 
   if (error) {
     return <p className="text-sm text-gray-400">{error}</p>;

--- a/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
+++ b/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
@@ -226,65 +226,24 @@ const MainView: FC<{
   animationMap: { current: Map<number, DecodedAnimation[]> };
   selectedIndex: number;
   animation: AnimationSequence | null;
+  isPlaying: boolean;
   onPrevious: () => void;
   onNext: () => void;
-  onSelectFrame: (index: number) => void;
+  startAnimation: () => void;
+  stopAnimation: () => void;
 }> = ({
   frames,
   bitmapMap,
   animationMap,
   selectedIndex,
   animation,
+  isPlaying,
   onPrevious,
   onNext,
-  onSelectFrame,
+  startAnimation,
+  stopAnimation,
 }) => {
   const selectedFrame = frames[selectedIndex];
-  const [isPlaying, setIsPlaying] = useState(false);
-  const animationPosRef = useRef(0);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const stopAnimation = useCallback(() => {
-    if (timeoutRef.current !== null) {
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
-    }
-    setIsPlaying(false);
-  }, []);
-
-  const scheduleNext = useCallback(
-    (pos: number) => {
-      if (!animation) return;
-      const current = animation[pos];
-      timeoutRef.current = setTimeout(() => {
-        const nextPos = (pos + 1) % animation.length;
-        animationPosRef.current = nextPos;
-        onSelectFrame(animation[nextPos].frameIndex);
-        scheduleNext(nextPos);
-      }, current.duration);
-    },
-    [animation, onSelectFrame],
-  );
-
-  const startAnimation = useCallback(() => {
-    if (!animation || animation.length === 0) return;
-    setIsPlaying(true);
-    const startPos = animationPosRef.current;
-    onSelectFrame(animation[startPos].frameIndex);
-    scheduleNext(startPos);
-  }, [animation, onSelectFrame, scheduleNext]);
-
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
-    };
-  }, []);
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: animation change triggers position reset
-  useEffect(() => {
-    stopAnimation();
-    animationPosRef.current = 0;
-  }, [animation, stopAnimation]);
 
   return (
     <div className="flex flex-col gap-4 flex-1 md:w-3/4 md:px-4 md:py-2">
@@ -320,6 +279,12 @@ const MainView: FC<{
                 )
               }
               onClick={isPlaying ? stopAnimation : startAnimation}
+              aria-label={
+                isPlaying ? "アニメーションを一時停止" : "アニメーションを再生"
+              }
+              title={
+                isPlaying ? "アニメーションを一時停止" : "アニメーションを再生"
+              }
             />
           )}
         </div>
@@ -342,18 +307,24 @@ const SlidePreviewContainer: FC<{
   animationMap: { current: Map<number, DecodedAnimation[]> };
   selectedIndex: number;
   animation: AnimationSequence | null;
+  isPlaying: boolean;
   onSelectFrame: (index: number) => void;
   onPrevious: () => void;
   onNext: () => void;
+  startAnimation: () => void;
+  stopAnimation: () => void;
 }> = ({
   frames,
   bitmapMap,
   animationMap,
   selectedIndex,
   animation,
+  isPlaying,
   onSelectFrame,
   onPrevious,
   onNext,
+  startAnimation,
+  stopAnimation,
 }) => {
   return (
     <div className="flex flex-col-reverse md:flex-row gap-2 h-auto aspect-video rounded bg-secondary p-2">
@@ -369,9 +340,11 @@ const SlidePreviewContainer: FC<{
         animationMap={animationMap}
         selectedIndex={selectedIndex}
         animation={animation}
+        isPlaying={isPlaying}
         onPrevious={onPrevious}
         onNext={onNext}
-        onSelectFrame={onSelectFrame}
+        startAnimation={startAnimation}
+        stopAnimation={stopAnimation}
       />
     </div>
   );
@@ -396,8 +369,83 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
   const [animation, setAnimation] = useState<AnimationSequence | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
   const bitmapMap = useRef<Map<number, ImageBitmap>>(new Map());
   const animationMap = useRef<Map<number, DecodedAnimation[]>>(new Map());
+  const animationRef = useRef<AnimationSequence | null>(null);
+  const animationPosRef = useRef(0);
+  const selectedIndexRef = useRef(0);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Keep refs in sync so callbacks always see the latest values without stale closures
+  animationRef.current = animation;
+  selectedIndexRef.current = selectedIndex;
+
+  const stopAnimation = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setIsPlaying(false);
+  }, []);
+
+  const scheduleNext = useCallback((pos: number) => {
+    const anim = animationRef.current;
+    if (!anim) return;
+    const current = anim[pos];
+    timeoutRef.current = setTimeout(() => {
+      const nextPos = (pos + 1) % anim.length;
+      animationPosRef.current = nextPos;
+      setSelectedIndex(anim[nextPos].frameIndex);
+      scheduleNext(nextPos);
+    }, current.duration);
+  }, []);
+
+  const startAnimation = useCallback(() => {
+    const anim = animationRef.current;
+    if (!anim || anim.length === 0) return;
+    // Sync start position to the currently displayed slide via ref (avoids side effects in state updater)
+    const matchPos = anim.findIndex(
+      (f) => f.frameIndex === selectedIndexRef.current,
+    );
+    const startPos = matchPos >= 0 ? matchPos : 0;
+    animationPosRef.current = startPos;
+    setSelectedIndex(anim[startPos].frameIndex);
+    setIsPlaying(true);
+    scheduleNext(startPos);
+  }, [scheduleNext]);
+
+  // Stop animation and reset position when the animation sequence changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: animation change triggers position reset
+  useEffect(() => {
+    stopAnimation();
+    animationPosRef.current = 0;
+  }, [animation, stopAnimation]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const handlePrevious = useCallback(() => {
+    stopAnimation();
+    setSelectedIndex((prev) => Math.max(0, prev - 1));
+  }, [stopAnimation]);
+
+  const handleNext = useCallback(() => {
+    stopAnimation();
+    setSelectedIndex((prev) => Math.min((frames?.length ?? 1) - 1, prev + 1));
+  }, [stopAnimation, frames]);
+
+  const handleSelectFrame = useCallback(
+    (index: number) => {
+      stopAnimation();
+      setSelectedIndex(index);
+    },
+    [stopAnimation],
+  );
 
   useEffect(() => {
     setFrames(null);
@@ -499,14 +547,6 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
     };
   }, [urls]);
 
-  const handlePrevious = () => {
-    setSelectedIndex((prev) => Math.max(0, prev - 1));
-  };
-
-  const handleNext = () => {
-    setSelectedIndex((prev) => Math.min((frames?.length ?? 0) - 1, prev + 1));
-  };
-
   if (error) {
     return <p className="text-sm text-gray-400">{error}</p>;
   }
@@ -534,9 +574,12 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
       animationMap={animationMap}
       selectedIndex={selectedIndex}
       animation={animation}
-      onSelectFrame={setSelectedIndex}
+      isPlaying={isPlaying}
+      onSelectFrame={handleSelectFrame}
       onPrevious={handlePrevious}
       onNext={handleNext}
+      startAnimation={startAnimation}
+      stopAnimation={stopAnimation}
     />
   );
 };

--- a/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
+++ b/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
@@ -125,9 +125,12 @@ const MainSlideDisplay: FC<{
           lastTimes[i] = time;
         } else {
           const interval = 1000 / anim.fps;
-          if (time - lastTimes[i] >= interval) {
+          const elapsed = time - lastTimes[i];
+          if (elapsed >= interval) {
             frameIndices[i] = (frameIndices[i] + 1) % anim.frames.length;
-            lastTimes[i] += interval;
+            // Absorb all accumulated lag (e.g. after tab hide/show) into a single
+            // frame advance, preserving only the sub-interval remainder.
+            lastTimes[i] = time - (elapsed % interval);
           }
         }
 

--- a/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
+++ b/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
@@ -398,10 +398,9 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
     setIsPlaying(false);
   }, []);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: empty deps intentional —
-  // scheduleNext must have a stable identity so the recursive chain inside the timeout
-  // callback always refers to the same function instance. All mutable state is accessed
-  // through refs (animationRef), not captured variables.
+  // Empty deps intentional: scheduleNext must have a stable identity so the recursive
+  // chain inside the timeout callback always refers to the same function instance.
+  // All mutable state is accessed through refs (animationRef), not captured variables.
   const scheduleNext = useCallback((pos: number) => {
     const anim = animationRef.current;
     if (!anim) return;

--- a/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
+++ b/src/app/(_)/files/[fileId]/_components/SlidePreview.tsx
@@ -120,6 +120,8 @@ const MainSlideDisplay: FC<{
         const anim = animations[i];
         if (anim.frames.length === 0) continue;
 
+        if (!Number.isFinite(anim.fps) || anim.fps <= 0) continue;
+
         if (lastTimes[i] < 0) {
           // First draw: initialize this animation's timer
           lastTimes[i] = time;
@@ -393,12 +395,16 @@ export const SlidePreview: FC<{ urls: string[] }> = ({ urls }) => {
     const anim = animationRef.current;
     if (!anim) return;
     const current = anim[pos];
+    const duration =
+      Number.isFinite(current.duration) && current.duration > 0
+        ? current.duration
+        : 100;
     timeoutRef.current = setTimeout(() => {
       const nextPos = (pos + 1) % anim.length;
       animationPosRef.current = nextPos;
       setSelectedIndex(anim[nextPos].frameIndex);
       scheduleNext(nextPos);
-    }, current.duration);
+    }, duration);
   }, []);
 
   const startAnimation = useCallback(() => {

--- a/src/app/api/proxy-google-image/route.ts
+++ b/src/app/api/proxy-google-image/route.ts
@@ -1,21 +1,12 @@
-const TRUSTED_HOSTNAMES = [
-  ".google.com",
-  ".googleapis.com",
-  ".googleusercontent.com",
-];
-
-const isTrustedOrigin = (url: string): boolean => {
-  try {
-    const { hostname } = new URL(url);
-    return TRUSTED_HOSTNAMES.some(
-      (suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix),
-    );
-  } catch {
-    return false;
-  }
-};
+import { auth } from "@/auth";
+import { isTrustedOrigin } from "@/lib/google/trustedOrigins";
 
 export async function GET(request: Request): Promise<Response> {
+  const session = await auth();
+  if (!session?.user) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
   const { searchParams } = new URL(request.url);
   const targetUrl = searchParams.get("url");
 
@@ -29,16 +20,18 @@ export async function GET(request: Request): Promise<Response> {
       return new Response(null, { status: upstream.status });
     }
 
-    const buffer = await upstream.arrayBuffer();
     const contentType =
       upstream.headers.get("Content-Type") ?? "application/octet-stream";
+    const contentLength = upstream.headers.get("Content-Length");
 
-    return new Response(buffer, {
-      headers: {
-        "Content-Type": contentType,
-        "Cache-Control": "private, max-age=300",
-      },
-    });
+    const headers: Record<string, string> = {
+      "Content-Type": contentType,
+      "Cache-Control": "private, max-age=300",
+      "X-Content-Type-Options": "nosniff",
+    };
+    if (contentLength) headers["Content-Length"] = contentLength;
+
+    return new Response(upstream.body ?? new Uint8Array(0), { headers });
   } catch {
     return new Response("Internal Server Error", { status: 500 });
   }

--- a/src/app/api/proxy-google-image/route.ts
+++ b/src/app/api/proxy-google-image/route.ts
@@ -25,14 +25,14 @@ export async function GET(request: Request): Promise<Response> {
 
     const contentType =
       upstream.headers.get("Content-Type") ?? "application/octet-stream";
-    const contentLength = upstream.headers.get("Content-Length");
 
+    // Do not forward Content-Length: fetch() decompresses gzip/brotli transparently,
+    // so the upstream value reflects the compressed size and would mismatch the body.
     const headers: Record<string, string> = {
       "Content-Type": contentType,
       "Cache-Control": "private, max-age=300",
       "X-Content-Type-Options": "nosniff",
     };
-    if (contentLength) headers["Content-Length"] = contentLength;
 
     return new Response(upstream.body ?? new Uint8Array(0), { headers });
   } catch {

--- a/src/app/api/proxy-google-image/route.ts
+++ b/src/app/api/proxy-google-image/route.ts
@@ -80,7 +80,9 @@ export async function GET(request: Request): Promise<Response> {
           chunks.push(value);
         }
       } finally {
-        await reader.cancel();
+        // Ignore cancel() rejection (stream may already be closed/errored) so
+        // it does not override a 413 return already issued from inside the loop.
+        reader.cancel().catch(() => {});
       }
     }
 

--- a/src/app/api/proxy-google-image/route.ts
+++ b/src/app/api/proxy-google-image/route.ts
@@ -1,7 +1,21 @@
 import { auth } from "@/auth";
+import { GIF_SIZE_CAP } from "@/const/config";
 import { isTrustedOrigin } from "@/lib/google/trustedOrigins";
 
-const PROXY_SIZE_CAP = 20 * 1024 * 1024; // 20 MB — matches client-side GIF_SIZE_CAP
+// Allow only known non-scriptable raster/binary types.
+// image/svg+xml is intentionally excluded: SVG is executable XML (inline <script>,
+// event handlers) and would enable XSS from attacker-controlled Google-hosted content.
+const ALLOWED_CONTENT_TYPES = new Set([
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/bmp",
+  "image/tiff",
+  "image/x-icon",
+  "image/vnd.microsoft.icon",
+  "application/octet-stream",
+]);
 
 export async function GET(request: Request): Promise<Response> {
   const session = await auth();
@@ -22,37 +36,27 @@ export async function GET(request: Request): Promise<Response> {
       signal: AbortSignal.timeout(15_000),
     });
     if (upstream.status >= 300 && upstream.status < 400) {
+      await upstream.body?.cancel();
       return new Response("Forbidden", { status: 403 });
     }
     if (!upstream.ok) {
+      await upstream.body?.cancel();
       return new Response(null, { status: upstream.status });
     }
 
     const contentType =
       upstream.headers.get("Content-Type") ?? "application/octet-stream";
 
-    // Allow only known non-scriptable raster/binary types.
-    // image/svg+xml is intentionally excluded: SVG is executable XML (inline <script>,
-    // event handlers) and would enable XSS from attacker-controlled Google-hosted content.
-    const ALLOWED_CONTENT_TYPES = new Set([
-      "image/gif",
-      "image/jpeg",
-      "image/png",
-      "image/webp",
-      "image/bmp",
-      "image/tiff",
-      "image/x-icon",
-      "image/vnd.microsoft.icon",
-      "application/octet-stream",
-    ]);
     const baseContentType = contentType.split(";")[0].trim();
     if (!ALLOWED_CONTENT_TYPES.has(baseContentType)) {
+      await upstream.body?.cancel();
       return new Response("Forbidden", { status: 403 });
     }
 
     // Reject early when Content-Length exceeds cap (not always present).
     const cl = Number(upstream.headers.get("Content-Length"));
-    if (Number.isFinite(cl) && cl > PROXY_SIZE_CAP) {
+    if (Number.isFinite(cl) && cl > GIF_SIZE_CAP) {
+      await upstream.body?.cancel();
       return new Response("Content Too Large", { status: 413 });
     }
 
@@ -67,7 +71,7 @@ export async function GET(request: Request): Promise<Response> {
           const { done, value } = await reader.read();
           if (done) break;
           totalBytes += value.byteLength;
-          if (totalBytes > PROXY_SIZE_CAP) {
+          if (totalBytes > GIF_SIZE_CAP) {
             return new Response("Content Too Large", { status: 413 });
           }
           chunks.push(value);

--- a/src/app/api/proxy-google-image/route.ts
+++ b/src/app/api/proxy-google-image/route.ts
@@ -56,13 +56,6 @@ export async function GET(request: Request): Promise<Response> {
       return new Response("Forbidden", { status: 403 });
     }
 
-    // Reject early when Content-Length exceeds cap (not always present).
-    const cl = Number(upstream.headers.get("Content-Length"));
-    if (Number.isFinite(cl) && cl > GIF_SIZE_CAP) {
-      await upstream.body?.cancel();
-      return new Response("Content Too Large", { status: 413 });
-    }
-
     // Buffer the body so we can enforce the cap before committing to a 200 response.
     // Streaming would send 200 before we know the total size, making a 413 impossible.
     const reader = upstream.body?.getReader();

--- a/src/app/api/proxy-google-image/route.ts
+++ b/src/app/api/proxy-google-image/route.ts
@@ -5,6 +5,9 @@ import { isTrustedOrigin } from "@/lib/google/trustedOrigins";
 // Allow only known non-scriptable raster/binary types.
 // image/svg+xml is intentionally excluded: SVG is executable XML (inline <script>,
 // event handlers) and would enable XSS from attacker-controlled Google-hosted content.
+// application/octet-stream is included for CDN responses that omit a specific MIME type;
+// callers MUST validate the actual content bytes (e.g. via isGif()) before treating the
+// payload as any specific format — this proxy does not perform content-level validation.
 const ALLOWED_CONTENT_TYPES = new Set([
   "image/gif",
   "image/jpeg",

--- a/src/app/api/proxy-google-image/route.ts
+++ b/src/app/api/proxy-google-image/route.ts
@@ -1,0 +1,45 @@
+const TRUSTED_HOSTNAMES = [
+  ".google.com",
+  ".googleapis.com",
+  ".googleusercontent.com",
+];
+
+const isTrustedOrigin = (url: string): boolean => {
+  try {
+    const { hostname } = new URL(url);
+    return TRUSTED_HOSTNAMES.some(
+      (suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix),
+    );
+  } catch {
+    return false;
+  }
+};
+
+export async function GET(request: Request): Promise<Response> {
+  const { searchParams } = new URL(request.url);
+  const targetUrl = searchParams.get("url");
+
+  if (!targetUrl || !isTrustedOrigin(targetUrl)) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  try {
+    const upstream = await fetch(targetUrl);
+    if (!upstream.ok) {
+      return new Response(null, { status: upstream.status });
+    }
+
+    const buffer = await upstream.arrayBuffer();
+    const contentType =
+      upstream.headers.get("Content-Type") ?? "application/octet-stream";
+
+    return new Response(buffer, {
+      headers: {
+        "Content-Type": contentType,
+        "Cache-Control": "private, max-age=300",
+      },
+    });
+  } catch {
+    return new Response("Internal Server Error", { status: 500 });
+  }
+}

--- a/src/app/api/proxy-google-image/route.ts
+++ b/src/app/api/proxy-google-image/route.ts
@@ -1,6 +1,8 @@
 import { auth } from "@/auth";
 import { isTrustedOrigin } from "@/lib/google/trustedOrigins";
 
+const PROXY_SIZE_CAP = 20 * 1024 * 1024; // 20 MB — matches client-side GIF_SIZE_CAP
+
 export async function GET(request: Request): Promise<Response> {
   const session = await auth();
   if (!session?.user) {
@@ -15,7 +17,10 @@ export async function GET(request: Request): Promise<Response> {
   }
 
   try {
-    const upstream = await fetch(targetUrl, { redirect: "manual" });
+    const upstream = await fetch(targetUrl, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(15_000),
+    });
     if (upstream.status >= 300 && upstream.status < 400) {
       return new Response("Forbidden", { status: 403 });
     }
@@ -26,6 +31,59 @@ export async function GET(request: Request): Promise<Response> {
     const contentType =
       upstream.headers.get("Content-Type") ?? "application/octet-stream";
 
+    // Allow only known non-scriptable raster/binary types.
+    // image/svg+xml is intentionally excluded: SVG is executable XML (inline <script>,
+    // event handlers) and would enable XSS from attacker-controlled Google-hosted content.
+    const ALLOWED_CONTENT_TYPES = new Set([
+      "image/gif",
+      "image/jpeg",
+      "image/png",
+      "image/webp",
+      "image/bmp",
+      "image/tiff",
+      "image/x-icon",
+      "image/vnd.microsoft.icon",
+      "application/octet-stream",
+    ]);
+    const baseContentType = contentType.split(";")[0].trim();
+    if (!ALLOWED_CONTENT_TYPES.has(baseContentType)) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    // Reject early when Content-Length exceeds cap (not always present).
+    const cl = Number(upstream.headers.get("Content-Length"));
+    if (Number.isFinite(cl) && cl > PROXY_SIZE_CAP) {
+      return new Response("Content Too Large", { status: 413 });
+    }
+
+    // Buffer the body so we can enforce the cap before committing to a 200 response.
+    // Streaming would send 200 before we know the total size, making a 413 impossible.
+    const reader = upstream.body?.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    if (reader) {
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          totalBytes += value.byteLength;
+          if (totalBytes > PROXY_SIZE_CAP) {
+            return new Response("Content Too Large", { status: 413 });
+          }
+          chunks.push(value);
+        }
+      } finally {
+        await reader.cancel();
+      }
+    }
+
+    const body = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      body.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+
     // Do not forward Content-Length: fetch() decompresses gzip/brotli transparently,
     // so the upstream value reflects the compressed size and would mismatch the body.
     const headers: Record<string, string> = {
@@ -34,8 +92,9 @@ export async function GET(request: Request): Promise<Response> {
       "X-Content-Type-Options": "nosniff",
     };
 
-    return new Response(upstream.body ?? new Uint8Array(0), { headers });
-  } catch {
+    return new Response(body, { headers });
+  } catch (e) {
+    console.error("proxy-google-image error:", e);
     return new Response("Internal Server Error", { status: 500 });
   }
 }

--- a/src/app/api/proxy-google-image/route.ts
+++ b/src/app/api/proxy-google-image/route.ts
@@ -15,7 +15,10 @@ export async function GET(request: Request): Promise<Response> {
   }
 
   try {
-    const upstream = await fetch(targetUrl);
+    const upstream = await fetch(targetUrl, { redirect: "manual" });
+    if (upstream.status >= 300 && upstream.status < 400) {
+      return new Response("Forbidden", { status: 403 });
+    }
     if (!upstream.ok) {
       return new Response(null, { status: upstream.status });
     }

--- a/src/app/api/proxy-google-image/route.ts
+++ b/src/app/api/proxy-google-image/route.ts
@@ -56,6 +56,11 @@ export async function GET(request: Request): Promise<Response> {
       return new Response("Forbidden", { status: 403 });
     }
 
+    // GIF_SIZE_CAP doubles as a generic per-asset cap for every allowed content type
+    // here, not just GIFs — the name is historical (the GIF reader was the first caller
+    // to need a shared limit). 20 MB is generous for Google-served thumbnails of any
+    // raster format we proxy.
+    //
     // Buffer the body so we can enforce the cap before committing to a 200 response.
     // Streaming would send 200 before we know the total size, making a 413 impossible.
     const reader = upstream.body?.getReader();

--- a/src/const/config.ts
+++ b/src/const/config.ts
@@ -1,3 +1,5 @@
+export const GIF_SIZE_CAP = 20 * 1024 * 1024; // 20 MB — shared by the proxy and client GIF reader
+
 export const IMAGE_DIFF_THRESHOLD = 10;
 export const IMAGE_BOUNDING_BOX_PENALTY_FACTOR = 0.1;
 export const IMAGE_BOUNDING_BOX_LIMIT = 8;

--- a/src/lib/eia/compressEIAv1.ts
+++ b/src/lib/eia/compressEIAv1.ts
@@ -289,7 +289,7 @@ const compressEIAv1Part = async (
     c: "lz4",
     v: usesAnimationFrameSizeV2 ? 2 : 1,
     f: features,
-    e: ["note", ...(usedFeatures.has("Feature:animation") ? ["a"] : [])],
+    e: ["note", ...(usedFeatures.has("Feature:animation") ? (["a"] as const) : [])],
     i: files,
     m: signage,
   };

--- a/src/lib/eia/compressEIAv1.ts
+++ b/src/lib/eia/compressEIAv1.ts
@@ -183,9 +183,10 @@ const compressEIAv1Part = async (
       for (const [animIndex, anim] of anims.entries()) {
         const frameRefs: EIAAnimationFrameRef[] = [];
         let hasCroppedFrames = false;
+        if (anim.frames.length === 0) continue;
         usedFormats.add(anim.format);
-        const frameWidth = anim.frames[0]?.rect.width ?? anim.w;
-        const frameHeight = anim.frames[0]?.rect.height ?? anim.h;
+        const frameWidth = anim.frames[0].rect.width;
+        const frameHeight = anim.frames[0].rect.height;
         for (const [frameIndex, frame] of anim.frames.entries()) {
           if (frame.format !== anim.format) {
             throw new Error(
@@ -289,7 +290,10 @@ const compressEIAv1Part = async (
     c: "lz4",
     v: usesAnimationFrameSizeV2 ? 2 : 1,
     f: features,
-    e: ["note", ...(usedFeatures.has("Feature:animation") ? (["a"] as const) : [])],
+    e: [
+      "note",
+      ...(usedFeatures.has("Feature:animation") ? (["a"] as const) : []),
+    ],
     i: files,
     m: signage,
   };

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -6,6 +6,7 @@ import type {
   PageSize,
   PixelRect,
 } from "@/_types/lib/google/slideGeometry";
+import { GIF_SIZE_CAP } from "@/const/config";
 import { type ParsedFrame, decompressFrames, parseGIF } from "gifuct-js";
 import { emuToPixelRect } from "./emuToPixel";
 import { isTrustedOrigin } from "./trustedOrigins";
@@ -16,7 +17,6 @@ const MAX_STORED_FRAME_DIMENSION = 512;
 const MAX_FRAMES = 60;
 const MAX_SOURCE_FRAMES = 500;
 const MAX_PREVIEW_FPS = 15;
-const GIF_SIZE_CAP = 20 * 1024 * 1024; // 20 MB
 
 const isGif = (buffer: ArrayBuffer): boolean => {
   if (buffer.byteLength < 6) return false;
@@ -313,12 +313,8 @@ export const extractGifAnimations = async (
   pageSize: PageSize,
   canvasSize: CanvasSize,
   baseSlideCanvas: OffscreenCanvas,
-  token: string,
+  signal?: AbortSignal,
 ): Promise<SelectedFileAnimation[]> => {
-  if (!token) {
-    return [];
-  }
-
   const imageElements = pageElements
     .map((element) => {
       const contentUrl = element.image?.contentUrl;
@@ -362,7 +358,7 @@ export const extractGifAnimations = async (
         try {
           // lh7-rt.googleusercontent.com does not return CORS headers, so proxy through our own server.
           const proxyUrl = `/api/proxy-google-image?url=${encodeURIComponent(contentUrl)}`;
-          const fullResponse = await fetch(proxyUrl);
+          const fullResponse = await fetch(proxyUrl, { signal });
           if (!fullResponse.ok) return null;
 
           // Skip non-GIF content early if Content-Type indicates it's not a GIF.
@@ -385,6 +381,7 @@ export const extractGifAnimations = async (
           let oversized = false;
           try {
             while (true) {
+              signal?.throwIfAborted();
               const { done, value } = await reader.read();
               if (done) break;
               totalSize += value.byteLength;
@@ -484,6 +481,9 @@ export const extractGifAnimations = async (
   // Only GIFs that survived GIF-to-GIF intersection are still animated at render time.
   // GIFs removed by that filter are now static pixels in the base canvas and must be
   // treated as potential non-animated foreground blockers for surviving candidates.
+  // Invariant: survivors are pairwise non-overlapping (the pairwise check above marks
+  // BOTH i and j when their rects intersect), so survivingAnimatedElements.has() in the
+  // Z-order loop below can safely skip other survivors without missing any occlusion.
   const survivingAnimatedElements = new Set(
     animatedGifCandidates
       .filter((_, i) => !intersectingElementIndices.has(i))

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -388,6 +388,11 @@ export const extractGifAnimations = async (
       }
 
       // Read body in chunks so we can abort early without buffering everything.
+      // The size cap is also enforced server-side by /api/proxy-google-image (which
+      // returns 413, caught by the !ok check above), so this client-side guard is
+      // redundant in normal operation. Kept as defense-in-depth: if the proxy's cap
+      // is ever bypassed, raised, or the response is served from a different path,
+      // we still won't buffer arbitrarily large payloads into memory.
       const reader = fullResponse.body?.getReader();
       if (!reader) return null;
       const chunks: Uint8Array[] = [];

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -389,7 +389,7 @@ export const extractGifAnimations = async (
               chunks.push(value);
             }
           } finally {
-            reader.cancel();
+            await reader.cancel();
           }
           if (oversized) return null;
 

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -8,23 +8,7 @@ import type {
 } from "@/_types/lib/google/slideGeometry";
 import { type ParsedFrame, decompressFrames, parseGIF } from "gifuct-js";
 import { emuToPixelRect } from "./emuToPixel";
-
-const TRUSTED_HOSTNAMES = [
-  ".google.com",
-  ".googleapis.com",
-  ".googleusercontent.com",
-];
-
-const isTrustedOrigin = (url: string): boolean => {
-  try {
-    const { hostname } = new URL(url);
-    return TRUSTED_HOSTNAMES.some(
-      (suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix),
-    );
-  } catch {
-    return false;
-  }
-};
+import { isTrustedOrigin } from "./trustedOrigins";
 
 const MAX_GIF_DIMENSION = 256;
 const MAX_SOURCE_GIF_DIMENSION = 4096;
@@ -354,6 +338,18 @@ export const extractGifAnimations = async (
           const proxyUrl = `/api/proxy-google-image?url=${encodeURIComponent(contentUrl)}`;
           const fullResponse = await fetch(proxyUrl);
           if (!fullResponse.ok) return null;
+
+          // Skip non-GIF content early if Content-Type indicates it's not a GIF.
+          // Fall through for octet-stream/missing headers and let isGif() verify the bytes.
+          const contentType = fullResponse.headers.get("Content-Type") ?? "";
+          if (
+            contentType.length > 0 &&
+            !contentType.includes("gif") &&
+            !contentType.includes("octet-stream")
+          ) {
+            await fullResponse.body?.cancel();
+            return null;
+          }
 
           const buffer = await fullResponse.arrayBuffer();
           if (!isGif(buffer)) return null;

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -350,100 +350,109 @@ export const extractGifAnimations = async (
       } => el !== null,
     );
 
-  const animatedGifCandidatesRaw = await Promise.all(
-    imageElements.map(
-      async ({ element, pixelRect }): Promise<AnimatedGifCandidate | null> => {
-        const contentUrl = element.image?.contentUrl;
-        if (!contentUrl || !isTrustedOrigin(contentUrl)) return null;
-        try {
-          // lh7-rt.googleusercontent.com does not return CORS headers, so proxy through our own server.
-          const proxyUrl = `/api/proxy-google-image?url=${encodeURIComponent(contentUrl)}`;
-          const fullResponse = await fetch(proxyUrl, { signal });
-          if (!fullResponse.ok) return null;
+  const fetchGifCandidate = async ({
+    element,
+    pixelRect,
+  }: (typeof imageElements)[number]): Promise<AnimatedGifCandidate | null> => {
+    const contentUrl = element.image?.contentUrl;
+    if (!contentUrl || !isTrustedOrigin(contentUrl)) return null;
+    try {
+      // lh7-rt.googleusercontent.com does not return CORS headers, so proxy through our own server.
+      const proxyUrl = `/api/proxy-google-image?url=${encodeURIComponent(contentUrl)}`;
+      const fullResponse = await fetch(proxyUrl, { signal });
+      if (!fullResponse.ok) return null;
 
-          // Skip non-GIF content early if Content-Type indicates it's not a GIF.
-          // Fall through for octet-stream/missing headers and let isGif() verify the bytes.
-          const contentType = fullResponse.headers.get("Content-Type") ?? "";
-          if (
-            contentType.length > 0 &&
-            !contentType.includes("gif") &&
-            !contentType.includes("octet-stream")
-          ) {
-            await fullResponse.body?.cancel();
-            return null;
+      // Skip non-GIF content early if Content-Type indicates it's not a GIF.
+      // Fall through for octet-stream/missing headers and let isGif() verify the bytes.
+      const contentType = fullResponse.headers.get("Content-Type") ?? "";
+      if (
+        contentType.length > 0 &&
+        !contentType.includes("gif") &&
+        !contentType.includes("octet-stream")
+      ) {
+        await fullResponse.body?.cancel();
+        return null;
+      }
+
+      // Read body in chunks so we can abort early without buffering everything.
+      const reader = fullResponse.body?.getReader();
+      if (!reader) return null;
+      const chunks: Uint8Array[] = [];
+      let totalSize = 0;
+      let oversized = false;
+      try {
+        while (true) {
+          signal?.throwIfAborted();
+          const { done, value } = await reader.read();
+          if (done) break;
+          totalSize += value.byteLength;
+          if (totalSize > GIF_SIZE_CAP) {
+            oversized = true;
+            break;
           }
-
-          // Read body in chunks so we can abort early without buffering everything.
-          const reader = fullResponse.body?.getReader();
-          if (!reader) return null;
-          const chunks: Uint8Array[] = [];
-          let totalSize = 0;
-          let oversized = false;
-          try {
-            while (true) {
-              signal?.throwIfAborted();
-              const { done, value } = await reader.read();
-              if (done) break;
-              totalSize += value.byteLength;
-              if (totalSize > GIF_SIZE_CAP) {
-                oversized = true;
-                break;
-              }
-              chunks.push(value);
-            }
-          } finally {
-            await reader.cancel();
-          }
-          if (oversized) return null;
-
-          const bodyBytes = new Uint8Array(totalSize);
-          let byteOffset = 0;
-          for (const chunk of chunks) {
-            bodyBytes.set(chunk, byteOffset);
-            byteOffset += chunk.byteLength;
-          }
-          const buffer = bodyBytes.buffer;
-          if (!isGif(buffer)) return null;
-
-          const gif = parseGIF(buffer);
-          const gifWidth = gif.lsd.width;
-          const gifHeight = gif.lsd.height;
-          if (
-            !(gifWidth > 0) ||
-            !(gifHeight > 0) ||
-            gifWidth > MAX_SOURCE_GIF_DIMENSION ||
-            gifHeight > MAX_SOURCE_GIF_DIMENSION
-          ) {
-            console.warn(
-              `extractGifAnimations: GIF dimensions out of range (${gifWidth}x${gifHeight}), skipping`,
-            );
-            return null;
-          }
-
-          if (gif.frames.length > MAX_SOURCE_FRAMES) {
-            console.warn(
-              `extractGifAnimations: too many frames (${gif.frames.length}), skipping`,
-            );
-            return null;
-          }
-
-          const rawFrames = decompressFrames(gif, true);
-          if (rawFrames.length <= 1) return null; // Static GIF, skip
-
-          return {
-            element,
-            pixelRect,
-            rawFrames,
-            gifWidth,
-            gifHeight,
-          } satisfies AnimatedGifCandidate;
-        } catch (e) {
-          console.warn("Failed to extract GIF animation:", e);
-          return null;
+          chunks.push(value);
         }
-      },
-    ),
-  );
+      } finally {
+        await reader.cancel();
+      }
+      if (oversized) return null;
+
+      const bodyBytes = new Uint8Array(totalSize);
+      let byteOffset = 0;
+      for (const chunk of chunks) {
+        bodyBytes.set(chunk, byteOffset);
+        byteOffset += chunk.byteLength;
+      }
+      const buffer = bodyBytes.buffer;
+      if (!isGif(buffer)) return null;
+
+      const gif = parseGIF(buffer);
+      const gifWidth = gif.lsd.width;
+      const gifHeight = gif.lsd.height;
+      if (
+        !(gifWidth > 0) ||
+        !(gifHeight > 0) ||
+        gifWidth > MAX_SOURCE_GIF_DIMENSION ||
+        gifHeight > MAX_SOURCE_GIF_DIMENSION
+      ) {
+        console.warn(
+          `extractGifAnimations: GIF dimensions out of range (${gifWidth}x${gifHeight}), skipping`,
+        );
+        return null;
+      }
+
+      if (gif.frames.length > MAX_SOURCE_FRAMES) {
+        console.warn(
+          `extractGifAnimations: too many frames (${gif.frames.length}), skipping`,
+        );
+        return null;
+      }
+
+      const rawFrames = decompressFrames(gif, true);
+      if (rawFrames.length <= 1) return null; // Static GIF, skip
+
+      return {
+        element,
+        pixelRect,
+        rawFrames,
+        gifWidth,
+        gifHeight,
+      } satisfies AnimatedGifCandidate;
+    } catch (e) {
+      console.warn("Failed to extract GIF animation:", e);
+      return null;
+    }
+  };
+
+  // Process in batches to cap concurrency and avoid saturating the proxy or
+  // triggering Google-side rate limits on slides with many embedded images.
+  const GIF_FETCH_CONCURRENCY = 4;
+  const animatedGifCandidatesRaw: Array<AnimatedGifCandidate | null> = [];
+  for (let i = 0; i < imageElements.length; i += GIF_FETCH_CONCURRENCY) {
+    const batch = imageElements.slice(i, i + GIF_FETCH_CONCURRENCY);
+    const batchResults = await Promise.all(batch.map(fetchGifCandidate));
+    animatedGifCandidatesRaw.push(...batchResults);
+  }
 
   const animatedGifCandidates = animatedGifCandidatesRaw.filter(
     (candidate): candidate is AnimatedGifCandidate => candidate !== null,

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -366,11 +366,6 @@ export const extractGifAnimations = async (
             return null;
           }
 
-          // Reject before downloading if Content-Length is known and exceeds cap.
-          const contentLength = fullResponse.headers.get("Content-Length");
-          if (contentLength && Number(contentLength) > GIF_SIZE_CAP)
-            return null;
-
           // Read body in chunks so we can abort early without buffering everything.
           const reader = fullResponse.body?.getReader();
           if (!reader) return null;
@@ -541,7 +536,7 @@ export const extractGifAnimations = async (
             storedFrameW,
             storedFrameH,
           );
-          frameCanvas.width = 0;
+          // OffscreenCanvas has no close() — rely on GC for resource release.
           return result;
         });
 

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -15,8 +15,8 @@ const MAX_SOURCE_GIF_DIMENSION = 4096;
 const MAX_STORED_FRAME_DIMENSION = 512;
 const MAX_FRAMES = 60;
 const MAX_SOURCE_FRAMES = 500;
-const TARGET_FPS = 2;
-const TARGET_FRAME_INTERVAL_MS = 1000 / TARGET_FPS;
+const MAX_PREVIEW_FPS = 15;
+const GIF_SIZE_CAP = 20 * 1024 * 1024; // 20 MB
 
 const isGif = (buffer: ArrayBuffer): boolean => {
   if (buffer.byteLength < 6) return false;
@@ -122,13 +122,28 @@ const computeAABBFromTransformedCorners = (
 };
 
 /**
- * Returns an ordered array of frame indices to output at TARGET_FPS.
- * A single source frame may appear multiple times if its delay spans
- * several TARGET_FRAME_INTERVAL_MS buckets, preserving correct playback tempo.
+ * Derives a preview FPS from the source GIF's median frame delay, capped at MAX_PREVIEW_FPS.
+ * Avoids downsampling smooth GIFs to the old fixed 2 fps.
  */
-const sampleFrameIndices = (frames: ParsedFrame[]): number[] => {
+const derivePreviewFps = (frames: ParsedFrame[]): number => {
+  if (frames.length === 0) return MAX_PREVIEW_FPS;
+  const delays = frames.map((f) => f.delay || 100).sort((a, b) => a - b);
+  const medianDelay = delays[Math.floor(delays.length / 2)];
+  return Math.min(MAX_PREVIEW_FPS, Math.max(1, Math.round(1000 / medianDelay)));
+};
+
+/**
+ * Returns an ordered array of frame indices to output at targetFps.
+ * A single source frame may appear multiple times if its delay spans
+ * several target-interval buckets, preserving correct playback tempo.
+ */
+const sampleFrameIndices = (
+  frames: ParsedFrame[],
+  targetFps: number,
+): number[] => {
   if (frames.length <= 1) return [0];
 
+  const targetIntervalMs = 1000 / targetFps;
   const indices: number[] = [];
   let accumulatedMs = 0;
   let nextSampleMs = 0;
@@ -140,7 +155,7 @@ const sampleFrameIndices = (frames: ParsedFrame[]): number[] => {
     // Emit this frame once per interval bucket it covers
     while (accumulatedMs > nextSampleMs && indices.length < MAX_FRAMES) {
       indices.push(i);
-      nextSampleMs += TARGET_FRAME_INTERVAL_MS;
+      nextSampleMs += targetIntervalMs;
     }
   }
   return indices.length > 0 ? indices : [0];
@@ -351,13 +366,40 @@ export const extractGifAnimations = async (
             return null;
           }
 
-          const GIF_SIZE_CAP = 20 * 1024 * 1024; // 20 MB
+          // Reject before downloading if Content-Length is known and exceeds cap.
           const contentLength = fullResponse.headers.get("Content-Length");
           if (contentLength && Number(contentLength) > GIF_SIZE_CAP)
             return null;
-          const buffer = await fullResponse.arrayBuffer();
-          // Post-buffer cap for chunked responses where Content-Length is absent
-          if (buffer.byteLength > GIF_SIZE_CAP) return null;
+
+          // Read body in chunks so we can abort early without buffering everything.
+          const reader = fullResponse.body?.getReader();
+          if (!reader) return null;
+          const chunks: Uint8Array[] = [];
+          let totalSize = 0;
+          let oversized = false;
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              totalSize += value.byteLength;
+              if (totalSize > GIF_SIZE_CAP) {
+                oversized = true;
+                break;
+              }
+              chunks.push(value);
+            }
+          } finally {
+            reader.cancel();
+          }
+          if (oversized) return null;
+
+          const bodyBytes = new Uint8Array(totalSize);
+          let byteOffset = 0;
+          for (const chunk of chunks) {
+            bodyBytes.set(chunk, byteOffset);
+            byteOffset += chunk.byteLength;
+          }
+          const buffer = bodyBytes.buffer;
           if (!isGif(buffer)) return null;
 
           const gif = parseGIF(buffer);
@@ -465,7 +507,8 @@ export const extractGifAnimations = async (
   const results = nonIntersectingAnimatedCandidates
     .map(({ pixelRect, rawFrames, gifWidth, gifHeight }) => {
       try {
-        const sampleIndices = sampleFrameIndices(rawFrames);
+        const previewFps = derivePreviewFps(rawFrames);
+        const sampleIndices = sampleFrameIndices(rawFrames, previewFps);
         const { w: targetW, h: targetH } = clampDimensions(gifWidth, gifHeight);
         const { w: storedFrameW, h: storedFrameH } = clampDimensions(
           pixelRect.w,
@@ -499,7 +542,7 @@ export const extractGifAnimations = async (
           y: pixelRect.y,
           w: pixelRect.w,
           h: pixelRect.h,
-          fps: TARGET_FPS,
+          fps: previewFps,
           frames,
         } satisfies SelectedFileAnimation;
       } catch (e) {

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -130,7 +130,9 @@ const derivePreviewFps = (frames: ParsedFrame[]): number => {
   // gifuct-js converts GCE delay (centiseconds) to ms via × 10; fall back to 100 ms
   // (matching sampleFrameIndices) when the field is missing or zero.
   const delays = frames.map((f) => f.delay || 100).sort((a, b) => a - b);
-  const medianDelay = delays[Math.floor(delays.length / 2)];
+  // Use lower-median index so even-length arrays don't pick the slower half.
+  // e.g. [100ms, 500ms] → lower median 100ms → 10fps, not upper median 500ms → 2fps.
+  const medianDelay = delays[Math.floor((delays.length - 1) / 2)];
   return Math.min(MAX_PREVIEW_FPS, Math.max(1, Math.round(1000 / medianDelay)));
 };
 
@@ -393,7 +395,9 @@ export const extractGifAnimations = async (
           chunks.push(value);
         }
       } finally {
-        await reader.cancel();
+        // Swallow cancel() rejection (stream may already be errored) so it does
+        // not replace the original read error that triggered this finally block.
+        reader.cancel().catch(() => {});
       }
       if (oversized) return null;
 

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -439,6 +439,9 @@ export const extractGifAnimations = async (
         gifHeight,
       } satisfies AnimatedGifCandidate;
     } catch (e) {
+      // Re-throw on abort so the batch loop exits immediately instead of
+      // continuing to fetch remaining batches after the caller cancelled.
+      if (signal?.aborted) throw e;
       console.warn("Failed to extract GIF animation:", e);
       return null;
     }
@@ -449,6 +452,7 @@ export const extractGifAnimations = async (
   const GIF_FETCH_CONCURRENCY = 4;
   const animatedGifCandidatesRaw: Array<AnimatedGifCandidate | null> = [];
   for (let i = 0; i < imageElements.length; i += GIF_FETCH_CONCURRENCY) {
+    signal?.throwIfAborted();
     const batch = imageElements.slice(i, i + GIF_FETCH_CONCURRENCY);
     const batchResults = await Promise.all(batch.map(fetchGifCandidate));
     animatedGifCandidatesRaw.push(...batchResults);

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -446,6 +446,26 @@ export const extractGifAnimations = async (
       const rawFrames = decompressFrames(gif, true);
       if (rawFrames.length <= 1) return null; // Static GIF, skip
 
+      // Spec-compliant GIF frames stay within the logical screen. Reject
+      // malformed frames upfront because the canvas API silently clips
+      // out-of-bounds get/putImageData regions, which corrupts blending and
+      // disposal-3 snapshots in subtle ways.
+      const framesInBounds = rawFrames.every(
+        (f) =>
+          f.dims.width > 0 &&
+          f.dims.height > 0 &&
+          f.dims.left >= 0 &&
+          f.dims.top >= 0 &&
+          f.dims.left + f.dims.width <= gifWidth &&
+          f.dims.top + f.dims.height <= gifHeight,
+      );
+      if (!framesInBounds) {
+        console.warn(
+          "extractGifAnimations: GIF has frame(s) outside logical canvas, skipping",
+        );
+        return null;
+      }
+
       return {
         element,
         pixelRect,

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -475,14 +475,22 @@ export const extractGifAnimations = async (
     elementZOrder.set(pageElements[i], i);
   }
 
-  const animatedElements = new Set(animatedGifCandidates.map((c) => c.element));
+  // Only GIFs that survived GIF-to-GIF intersection are still animated at render time.
+  // GIFs removed by that filter are now static pixels in the base canvas and must be
+  // treated as potential non-animated foreground blockers for surviving candidates.
+  const survivingAnimatedElements = new Set(
+    animatedGifCandidates
+      .filter((_, i) => !intersectingElementIndices.has(i))
+      .map((c) => c.element),
+  );
   const intersectingNonAnimatedIndices = new Set<number>();
   for (let i = 0; i < animatedGifCandidates.length; i++) {
+    if (intersectingElementIndices.has(i)) continue; // already filtered, skip
     const candidate = animatedGifCandidates[i];
     const gifZ = elementZOrder.get(candidate.element) ?? 0;
     for (const positioned of positionedElements) {
       if (positioned.element === candidate.element) continue;
-      if (animatedElements.has(positioned.element)) continue;
+      if (survivingAnimatedElements.has(positioned.element)) continue;
       const posZ = elementZOrder.get(positioned.element) ?? 0;
       if (posZ <= gifZ) continue; // Below the GIF — composited into background, safe to ignore
       if (rectsIntersect(candidate.pixelRect, positioned.pixelRect)) {

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -374,7 +374,10 @@ export const extractGifAnimations = async (
 
       // Skip non-GIF content early if Content-Type indicates it's not a GIF.
       // Fall through for octet-stream/missing headers and let isGif() verify the bytes.
-      const contentType = fullResponse.headers.get("Content-Type") ?? "";
+      // Normalize casing because servers may respond with e.g. "Image/GIF".
+      const contentType = (fullResponse.headers.get("Content-Type") ?? "")
+        .trim()
+        .toLowerCase();
       if (
         contentType.length > 0 &&
         !contentType.includes("gif") &&

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -322,7 +322,15 @@ export const extractGifAnimations = async (
       const contentUrl = element.image?.contentUrl;
       if (!contentUrl) return null;
       const pixelRect = toPixelRect(element, pageSize, canvasSize);
-      if (!pixelRect) return null;
+      if (!pixelRect) {
+        // Sheared or unsupported-transform image elements cannot be projected to
+        // a pixel rect and are not checked for GIF candidacy.
+        console.warn(
+          "extractGifAnimations: skipping image element with unsupported transform (shear/non-positive scale)",
+          element.transform,
+        );
+        return null;
+      }
 
       return { element, pixelRect };
     })

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -127,6 +127,8 @@ const computeAABBFromTransformedCorners = (
  */
 const derivePreviewFps = (frames: ParsedFrame[]): number => {
   if (frames.length === 0) return MAX_PREVIEW_FPS;
+  // gifuct-js converts GCE delay (centiseconds) to ms via × 10; fall back to 100 ms
+  // (matching sampleFrameIndices) when the field is missing or zero.
   const delays = frames.map((f) => f.delay || 100).sort((a, b) => a - b);
   const medianDelay = delays[Math.floor(delays.length / 2)];
   return Math.min(MAX_PREVIEW_FPS, Math.max(1, Math.round(1000 / medianDelay)));
@@ -226,6 +228,12 @@ const buildComposedFrames = (
     );
     const dstData = imageData.data;
     const srcData = frame.patch;
+    const expectedLength = frame.dims.width * frame.dims.height * 4;
+    if (srcData.length < expectedLength) {
+      console.warn(
+        `GIF frame patch is smaller than expected: got ${srcData.length} bytes, expected ${expectedLength} (${frame.dims.width}×${frame.dims.height})`,
+      );
+    }
     const pixelCount = Math.min(srcData.length, dstData.length);
     for (let p = 0; p < pixelCount; p += 4) {
       const srcA = srcData[p + 3] / 255;
@@ -233,6 +241,9 @@ const buildComposedFrames = (
 
       const dstA = dstData[p + 3] / 255;
       const outA = srcA + dstA * (1 - srcA);
+      // outA === 0 is unreachable here (srcA > 0 guarantees outA > 0) but guards
+      // against division by zero if floating-point behaviour ever changes.
+      if (outA === 0) continue;
 
       dstData[p] = Math.round(
         (srcData[p] * srcA + dstData[p] * dstA * (1 - srcA)) / outA,

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -351,10 +351,13 @@ export const extractGifAnimations = async (
             return null;
           }
 
+          const GIF_SIZE_CAP = 20 * 1024 * 1024; // 20 MB
           const contentLength = fullResponse.headers.get("Content-Length");
-          if (contentLength && Number(contentLength) > 20 * 1024 * 1024)
-            return null; // 20 MB cap
+          if (contentLength && Number(contentLength) > GIF_SIZE_CAP)
+            return null;
           const buffer = await fullResponse.arrayBuffer();
+          // Post-buffer cap for chunked responses where Content-Length is absent
+          if (buffer.byteLength > GIF_SIZE_CAP) return null;
           if (!isGif(buffer)) return null;
 
           const gif = parseGIF(buffer);

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -306,7 +306,6 @@ export const extractGifAnimations = async (
   token: string,
 ): Promise<SelectedFileAnimation[]> => {
   if (!token) {
-    console.warn("extractGifAnimations: empty token, skipping GIF extraction");
     return [];
   }
 
@@ -351,28 +350,13 @@ export const extractGifAnimations = async (
         const contentUrl = element.image?.contentUrl;
         if (!contentUrl || !isTrustedOrigin(contentUrl)) return null;
         try {
-          const rangeSniffResponse = await fetch(contentUrl, {
-            headers: {
-              Authorization: `Bearer ${token}`,
-              Range: "bytes=0-5",
-            },
-          });
-          if (!rangeSniffResponse.ok) return null;
+          // lh7-rt.googleusercontent.com does not return CORS headers, so proxy through our own server.
+          const proxyUrl = `/api/proxy-google-image?url=${encodeURIComponent(contentUrl)}`;
+          const fullResponse = await fetch(proxyUrl);
+          if (!fullResponse.ok) return null;
 
-          const headerBuffer = await rangeSniffResponse.arrayBuffer();
-          if (!isGif(headerBuffer)) return null;
-
-          let buffer = headerBuffer;
-          if (
-            rangeSniffResponse.status === 206 ||
-            headerBuffer.byteLength <= 6
-          ) {
-            const fullResponse = await fetch(contentUrl, {
-              headers: { Authorization: `Bearer ${token}` },
-            });
-            if (!fullResponse.ok) return null;
-            buffer = await fullResponse.arrayBuffer();
-          }
+          const buffer = await fullResponse.arrayBuffer();
+          if (!isGif(buffer)) return null;
 
           const gif = parseGIF(buffer);
           const gifWidth = gif.lsd.width;
@@ -439,13 +423,24 @@ export const extractGifAnimations = async (
     );
   }
 
+  // Z-order: elements later in pageElements are drawn on top (higher Z).
+  // Only elements drawn ABOVE the GIF can obscure it; elements below are already
+  // baked into the base slide composite and do not cause artifacts.
+  const elementZOrder = new Map<SlidePageElement, number>();
+  for (let i = 0; i < pageElements.length; i++) {
+    elementZOrder.set(pageElements[i], i);
+  }
+
   const animatedElements = new Set(animatedGifCandidates.map((c) => c.element));
   const intersectingNonAnimatedIndices = new Set<number>();
   for (let i = 0; i < animatedGifCandidates.length; i++) {
     const candidate = animatedGifCandidates[i];
+    const gifZ = elementZOrder.get(candidate.element) ?? 0;
     for (const positioned of positionedElements) {
       if (positioned.element === candidate.element) continue;
       if (animatedElements.has(positioned.element)) continue;
+      const posZ = elementZOrder.get(positioned.element) ?? 0;
+      if (posZ <= gifZ) continue; // Below the GIF — composited into background, safe to ignore
       if (rectsIntersect(candidate.pixelRect, positioned.pixelRect)) {
         intersectingNonAnimatedIndices.add(i);
         break;
@@ -455,7 +450,7 @@ export const extractGifAnimations = async (
 
   if (intersectingNonAnimatedIndices.size > 0) {
     console.warn(
-      `extractGifAnimations: skipping ${intersectingNonAnimatedIndices.size} animated GIF element(s) overlapping non-animated elements; preserving foreground overlap is not supported with RGB24 animation encoding`,
+      `extractGifAnimations: skipping ${intersectingNonAnimatedIndices.size} animated GIF element(s) with higher-Z non-animated elements overlapping; foreground overlap is not supported with RGB24 animation encoding`,
     );
   }
 

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -351,6 +351,9 @@ export const extractGifAnimations = async (
             return null;
           }
 
+          const contentLength = fullResponse.headers.get("Content-Length");
+          if (contentLength && Number(contentLength) > 20 * 1024 * 1024)
+            return null; // 20 MB cap
           const buffer = await fullResponse.arrayBuffer();
           if (!isGif(buffer)) return null;
 

--- a/src/lib/google/trustedOrigins.ts
+++ b/src/lib/google/trustedOrigins.ts
@@ -1,0 +1,16 @@
+export const TRUSTED_HOSTNAMES = [
+  ".google.com",
+  ".googleapis.com",
+  ".googleusercontent.com",
+];
+
+export const isTrustedOrigin = (url: string): boolean => {
+  try {
+    const { hostname } = new URL(url);
+    return TRUSTED_HOSTNAMES.some(
+      (suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix),
+    );
+  } catch {
+    return false;
+  }
+};

--- a/src/lib/google/trustedOrigins.ts
+++ b/src/lib/google/trustedOrigins.ts
@@ -2,11 +2,12 @@ export const TRUSTED_HOSTNAMES = [
   ".google.com",
   ".googleapis.com",
   ".googleusercontent.com",
-];
+] as const;
 
 export const isTrustedOrigin = (url: string): boolean => {
   try {
-    const { hostname } = new URL(url);
+    const { hostname, protocol } = new URL(url);
+    if (protocol !== "https:") return false;
     return TRUSTED_HOSTNAMES.some(
       (suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix),
     );

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -309,7 +309,15 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): DecodeResult => {
 
   let animation: AnimationSequence | null = null;
   if (manifest.m) {
-    const firstDeviceKey = Object.keys(manifest.m)[0];
+    const deviceKeys = Object.keys(manifest.m);
+    // Preview uses only the first device key. Multi-device EIA files carry separate
+    // sequences per display profile; selecting one is intentional here.
+    if (deviceKeys.length > 1) {
+      console.warn(
+        `EIA manifest has ${deviceKeys.length} device keys; preview uses only "${deviceKeys[0]}"`,
+      );
+    }
+    const firstDeviceKey = deviceKeys[0];
     if (firstDeviceKey !== undefined) {
       const items = manifest.m[firstDeviceKey];
       const seq: AnimationFrame[] = [];

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -9,6 +9,7 @@ import type {
   AnimationFrame,
   AnimationSequence,
   DecodeResult,
+  RawSignageItem,
   SlideAnimation,
   SlideFrame,
 } from "@/_types/slide-preview";
@@ -308,6 +309,7 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): DecodeResult => {
   }
 
   let animation: AnimationSequence | null = null;
+  let rawSignageItems: RawSignageItem[] | undefined;
   if (manifest.m) {
     const deviceKeys = Object.keys(manifest.m);
     // Preview uses only the first device key. Multi-device EIA files carry separate
@@ -320,6 +322,11 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): DecodeResult => {
     const firstDeviceKey = deviceKeys[0];
     if (firstDeviceKey !== undefined) {
       const items = manifest.m[firstDeviceKey];
+      // Preserve raw frame names so decodeSlides can do cross-part global resolution
+      rawSignageItems = items.map((item) => ({
+        frameName: item.f,
+        duration: item.d,
+      }));
       const seq: AnimationFrame[] = [];
       for (const item of items) {
         const arrayPos = nameToIndex.get(item.f);
@@ -330,5 +337,5 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): DecodeResult => {
     }
   }
 
-  return { frames: sortedFrames, animation };
+  return { frames: sortedFrames, animation, rawSignageItems };
 };

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -6,8 +6,6 @@ import type {
   EIAManifestV1,
 } from "@/_types/eia/v1";
 import type {
-  AnimationFrame,
-  AnimationSequence,
   DecodeResult,
   RawSignageItem,
   SlideAnimation,
@@ -124,7 +122,6 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): DecodeResult => {
   );
   const frameBuffers = new Map<string, Uint8Array>();
   const frames: SlideFrame[] = [];
-  const nameToIndex = new Map<string, number>();
 
   for (const item of manifest.i) {
     let decompressed: Uint8Array;
@@ -303,12 +300,6 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): DecodeResult => {
 
   const sortedFrames = frames.sort((a, b) => a.index - b.index);
 
-  // Build nameToIndex after sorting so positions reflect sorted order
-  for (let i = 0; i < sortedFrames.length; i++) {
-    nameToIndex.set(String(sortedFrames[i].index), i);
-  }
-
-  let animation: AnimationSequence | null = null;
   let rawSignageItems: RawSignageItem[] | undefined;
   if (manifest.m) {
     const deviceKeys = Object.keys(manifest.m);
@@ -327,15 +318,8 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): DecodeResult => {
         frameName: item.f,
         duration: item.d,
       }));
-      const seq: AnimationFrame[] = [];
-      for (const item of items) {
-        const arrayPos = nameToIndex.get(item.f);
-        if (arrayPos === undefined) continue;
-        seq.push({ frameIndex: arrayPos, duration: item.d });
-      }
-      if (seq.length > 0) animation = seq;
     }
   }
 
-  return { frames: sortedFrames, animation, rawSignageItems };
+  return { frames: sortedFrames, animation: null, rawSignageItems };
 };

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -127,9 +127,21 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): DecodeResult => {
     let decompressed: Uint8Array;
 
     if (binarySection !== null) {
+      if (item.s < 0 || item.l < 0 || item.s + item.l > binarySection.length) {
+        throw new Error(
+          `Frame "${item.n}" data out of bounds: offset ${item.s} + length ${item.l} ` +
+            `exceeds binary section size ${binarySection.length}`,
+        );
+      }
       const compressed = binarySection.subarray(item.s, item.s + item.l);
       decompressed = lz4Decompress(compressed, item.u, item.n);
     } else if (textSection !== null) {
+      if (item.s < 0 || item.l < 0 || item.s + item.l > textSection.length) {
+        throw new Error(
+          `Frame "${item.n}" data out of bounds: offset ${item.s} + length ${item.l} ` +
+            `exceeds text section size ${textSection.length}`,
+        );
+      }
       const b64 = textSection.substring(item.s, item.s + item.l);
       const compressed = base64ToUint8Array(b64);
       decompressed = lz4Decompress(compressed, item.u, item.n);
@@ -211,7 +223,11 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): DecodeResult => {
 
               for (let fi = 0; fi < meta.frames.length; fi++) {
                 const frameRef = meta.frames[fi];
-                if (frameRef.s + frameRef.l > binarySection.length) {
+                if (
+                  frameRef.s < 0 ||
+                  frameRef.l < 0 ||
+                  frameRef.s + frameRef.l > binarySection.length
+                ) {
                   throw new Error(
                     `Animation frame ref out of bounds: offset ${frameRef.s} + length ${frameRef.l} ` +
                       `exceeds binary section size ${binarySection.length}`,

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -5,7 +5,13 @@ import type {
   EIAFileV1CroppedPart,
   EIAManifestV1,
 } from "@/_types/eia/v1";
-import type { SlideAnimation, SlideFrame } from "@/_types/slide-preview";
+import type {
+  AnimationFrame,
+  AnimationSequence,
+  DecodeResult,
+  SlideAnimation,
+  SlideFrame,
+} from "@/_types/slide-preview";
 import lz4 from "lz4js";
 import { rgb24ToImageData, rgba32ToImageData } from "./rawImage2ImageData";
 
@@ -82,7 +88,7 @@ const applyRects = (
   return result;
 };
 
-export const decodeEIAv1 = (buffer: ArrayBuffer): SlideFrame[] => {
+export const decodeEIAv1 = (buffer: ArrayBuffer): DecodeResult => {
   const uint8 = new Uint8Array(buffer);
   const textDecoder = new TextDecoder();
 
@@ -117,6 +123,7 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): SlideFrame[] => {
   );
   const frameBuffers = new Map<string, Uint8Array>();
   const frames: SlideFrame[] = [];
+  const nameToIndex = new Map<string, number>();
 
   for (const item of manifest.i) {
     let decompressed: Uint8Array;
@@ -293,5 +300,27 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): SlideFrame[] => {
     }
   }
 
-  return frames.sort((a, b) => a.index - b.index);
+  const sortedFrames = frames.sort((a, b) => a.index - b.index);
+
+  // Build nameToIndex after sorting so positions reflect sorted order
+  for (let i = 0; i < sortedFrames.length; i++) {
+    nameToIndex.set(String(sortedFrames[i].index), i);
+  }
+
+  let animation: AnimationSequence | null = null;
+  if (manifest.m) {
+    const firstDeviceKey = Object.keys(manifest.m)[0];
+    if (firstDeviceKey !== undefined) {
+      const items = manifest.m[firstDeviceKey];
+      const seq: AnimationFrame[] = [];
+      for (const item of items) {
+        const arrayPos = nameToIndex.get(item.f);
+        if (arrayPos === undefined) continue;
+        seq.push({ frameIndex: arrayPos, duration: item.d });
+      }
+      if (seq.length > 0) animation = seq;
+    }
+  }
+
+  return { frames: sortedFrames, animation };
 };

--- a/src/lib/slidePreview/decodeSlides.ts
+++ b/src/lib/slidePreview/decodeSlides.ts
@@ -1,4 +1,9 @@
-import type { SlideFrame } from "@/_types/slide-preview";
+import type {
+  AnimationFrame,
+  AnimationSequence,
+  DecodeResult,
+  SlideFrame,
+} from "@/_types/slide-preview";
 import type { ManifestV0 } from "@/_types/text-zip/v0";
 import type { ManifestV1 } from "@/_types/text-zip/v1";
 import JSZip from "jszip";
@@ -15,7 +20,7 @@ const isEIA = (uint8: Uint8Array): boolean =>
 const decodePart = async (
   url: string,
   signal: AbortSignal,
-): Promise<SlideFrame[]> => {
+): Promise<DecodeResult> => {
   const response = await fetch(url, { signal });
   if (!response.ok)
     throw new Error(
@@ -49,15 +54,27 @@ const decodePart = async (
 export const decodeSlides = async (
   urls: string[],
   signal: AbortSignal,
-): Promise<SlideFrame[]> => {
+): Promise<DecodeResult> => {
   const allFrames: SlideFrame[] = [];
+  let mergedAnimation: AnimationSequence | null = null;
+
   for (const url of urls) {
-    const partFrames = await decodePart(url, signal);
+    const partResult = await decodePart(url, signal);
     const offset = allFrames.length;
-    const sorted = [...partFrames].sort((a, b) => a.index - b.index);
+    const sorted = [...partResult.frames].sort((a, b) => a.index - b.index);
     for (let i = 0; i < sorted.length; i++) {
       allFrames.push({ ...sorted[i], index: offset + i });
     }
+
+    if (partResult.animation && !mergedAnimation) {
+      mergedAnimation = partResult.animation.map(
+        (f: AnimationFrame): AnimationFrame => ({
+          ...f,
+          frameIndex: f.frameIndex + offset,
+        }),
+      );
+    }
   }
-  return allFrames;
+
+  return { frames: allFrames, animation: mergedAnimation };
 };

--- a/src/lib/slidePreview/decodeSlides.ts
+++ b/src/lib/slidePreview/decodeSlides.ts
@@ -66,13 +66,16 @@ export const decodeSlides = async (
       allFrames.push({ ...sorted[i], index: offset + i });
     }
 
-    if (partResult.animation && !mergedAnimation) {
-      mergedAnimation = partResult.animation.map(
+    if (partResult.animation) {
+      const adjusted = partResult.animation.map(
         (f: AnimationFrame): AnimationFrame => ({
           ...f,
           frameIndex: f.frameIndex + offset,
         }),
       );
+      mergedAnimation = mergedAnimation
+        ? [...mergedAnimation, ...adjusted]
+        : adjusted;
     }
   }
 

--- a/src/lib/slidePreview/decodeSlides.ts
+++ b/src/lib/slidePreview/decodeSlides.ts
@@ -2,6 +2,7 @@ import type {
   AnimationFrame,
   AnimationSequence,
   DecodeResult,
+  RawSignageItem,
   SlideFrame,
 } from "@/_types/slide-preview";
 import type { ManifestV0 } from "@/_types/text-zip/v0";
@@ -56,27 +57,38 @@ export const decodeSlides = async (
   signal: AbortSignal,
 ): Promise<DecodeResult> => {
   const allFrames: SlideFrame[] = [];
-  let mergedAnimation: AnimationSequence | null = null;
+  // Maps original EIA frame index (Number(item.n)) to global allFrames position
+  const eiaIndexToGlobalPos = new Map<number, number>();
+  let globalRawSignageItems: RawSignageItem[] | undefined;
 
   for (const url of urls) {
     const partResult = await decodePart(url, signal);
     const offset = allFrames.length;
     const sorted = [...partResult.frames].sort((a, b) => a.index - b.index);
     for (let i = 0; i < sorted.length; i++) {
+      // sorted[i].index == Number(item.n) in the EIA manifest (original global slide index)
+      eiaIndexToGlobalPos.set(sorted[i].index, offset + i);
       allFrames.push({ ...sorted[i], index: offset + i });
     }
 
-    if (partResult.animation) {
-      const adjusted = partResult.animation.map(
-        (f: AnimationFrame): AnimationFrame => ({
-          ...f,
-          frameIndex: f.frameIndex + offset,
-        }),
-      );
-      mergedAnimation = mergedAnimation
-        ? [...mergedAnimation, ...adjusted]
-        : adjusted;
+    // Take signage items from the first part that has them; all EIA parts carry
+    // the same full signage manifest so any part is sufficient.
+    if (!globalRawSignageItems && partResult.rawSignageItems) {
+      globalRawSignageItems = partResult.rawSignageItems;
     }
+  }
+
+  // Resolve the signage sequence globally so the original playback order is
+  // preserved even when slides are interleaved across part boundaries.
+  let mergedAnimation: AnimationSequence | null = null;
+  if (globalRawSignageItems) {
+    const seq: AnimationFrame[] = [];
+    for (const item of globalRawSignageItems) {
+      const globalPos = eiaIndexToGlobalPos.get(Number(item.frameName));
+      if (globalPos === undefined) continue;
+      seq.push({ frameIndex: globalPos, duration: item.duration });
+    }
+    if (seq.length > 0) mergedAnimation = seq;
   }
 
   return { frames: allFrames, animation: mergedAnimation };

--- a/src/lib/slidePreview/decodeTextZipV0.ts
+++ b/src/lib/slidePreview/decodeTextZipV0.ts
@@ -1,4 +1,4 @@
-import type { SlideFrame } from "@/_types/slide-preview";
+import type { DecodeResult, SlideFrame } from "@/_types/slide-preview";
 import type { ManifestV0 } from "@/_types/text-zip/v0";
 import type JSZip from "jszip";
 import { rgba32ToImageData } from "./rawImage2ImageData";
@@ -6,7 +6,7 @@ import { rgba32ToImageData } from "./rawImage2ImageData";
 export const decodeTextZipV0 = async (
   zip: JSZip,
   manifest: ManifestV0,
-): Promise<SlideFrame[]> => {
+): Promise<DecodeResult> => {
   const frames: SlideFrame[] = [];
   for (let i = 0; i < manifest.length; i++) {
     const item = manifest[i];
@@ -21,5 +21,5 @@ export const decodeTextZipV0 = async (
     });
   }
 
-  return frames;
+  return { frames, animation: null };
 };

--- a/src/lib/slidePreview/decodeTextZipV1.ts
+++ b/src/lib/slidePreview/decodeTextZipV1.ts
@@ -1,4 +1,4 @@
-import type { SlideFrame } from "@/_types/slide-preview";
+import type { DecodeResult, SlideFrame } from "@/_types/slide-preview";
 import type {
   ManifestV1,
   ManifestV1ExtensionCropped,
@@ -65,7 +65,7 @@ const applyRects = async (
 export const decodeTextZipV1 = async (
   zip: JSZip,
   manifest: ManifestV1,
-): Promise<SlideFrame[]> => {
+): Promise<DecodeResult> => {
   const basePaths = new Set(
     manifest.files
       .filter((f) => f.extensions?.cropped)
@@ -126,5 +126,5 @@ export const decodeTextZipV1 = async (
     }
   }
 
-  return frames;
+  return { frames, animation: null };
 };


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Play/pause controls for slide preview animations with external playback control
  * Signage-derived animation sequences preserved with per-frame durations
  * GIF preview extraction with adaptive preview frame rate and a global GIF size cap
  * Image proxy endpoint for fetching remote images with safe response headers and origin checks

* **Bug Fixes**
  * More robust animation timing; playback stops/resets on selection/decode changes
  * Occlusion/overlap detection respects stacking order
  * Proxy enforces trusted origins, content-type and size limits; requests are cancellable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements EIA signage animation playback (play/pause with per-frame timing) and GIF preview extraction for Google Slides, along with a server-side image proxy endpoint. All four issues raised in previous review threads have been addressed: the multi-part animation ordering is now globally resolved via `eiaIndexToGlobalPos`, the proxy now includes both auth and a size cap, and manual slide navigation now calls `stopAnimation` before updating the selected index.

<h3>Confidence Score: 5/5</h3>

PR is safe to merge; all previously flagged issues have been addressed and no new P0/P1 issues found.

All four prior review-thread issues (multi-part animation ordering, missing proxy auth/size limit, manual nav not stopping the timer) are correctly fixed. The new proxy, GIF extraction, and playback scheduling code is well-defended with bounds checks, abort support, trusted-origin guards, and content-type filtering. No P1 or P0 findings remain.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/api/proxy-google-image/route.ts | New proxy endpoint with session auth, trusted-origin allowlist, content-type allowlist, streaming size cap, and redirect blocking — well-guarded. |
| src/lib/slidePreview/decodeSlides.ts | Multi-part EIA decoding now does a single global signage-sequence resolution pass via eiaIndexToGlobalPos, correctly preserving inter-part playback order. |
| src/app/(_)/files/[fileId]/_components/SlidePreview.tsx | Animation play/pause with ref-based scheduling added; handlePrevious, handleNext, and handleSelectFrame all call stopAnimation before updating the index. |
| src/lib/google/extractGifAnimations.ts | New GIF extraction with adaptive FPS, proper GIF disposal handling, Z-order occlusion detection, size cap and abort support; batched proxy fetches cap concurrency. |
| src/lib/slidePreview/decodeEIAv1.ts | Animation metadata decoding from EIA extension field; rawSignageItems now returned for cross-part global resolution; safe bounds checks throughout. |
| src/app/(_)/convert/pick/_components/FileList/GooglePicker.tsx | AbortController added per pick operation with isStillActive() guard; slide processing made sequential to cap proxy concurrency; raceWithAbort helper wraps non-cancellable promises. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant SlidePreview
    participant decodeSlides
    participant decodeEIAv1
    participant extractGifAnimations
    participant Proxy as /api/proxy-google-image
    participant Google as Google CDN

    Browser->>SlidePreview: mount (urls[])
    SlidePreview->>decodeSlides: decodeSlides(urls, signal)
    loop each EIA part URL
        decodeSlides->>decodeEIAv1: decodeEIAv1(buffer)
        decodeEIAv1-->>decodeSlides: { frames, rawSignageItems }
    end
    Note over decodeSlides: Global signage resolution via eiaIndexToGlobalPos
    decodeSlides-->>SlidePreview: { frames, animation }

    SlidePreview->>extractGifAnimations: extractGifAnimations(pageElements, signal)
    loop batches of 4 image elements
        extractGifAnimations->>Proxy: GET /api/proxy-google-image?url=…
        Proxy->>Google: fetch(targetUrl, redirect:manual)
        Google-->>Proxy: image bytes
        Proxy-->>extractGifAnimations: proxied image (<=20 MB)
        extractGifAnimations->>extractGifAnimations: parseGIF -> buildComposedFrames
    end
    extractGifAnimations-->>SlidePreview: SlideAnimation[]

    SlidePreview->>Browser: render frames + play/pause controls
    Browser->>SlidePreview: play button click
    SlidePreview->>SlidePreview: scheduleNext(pos) loop via setTimeout
```

<sub>Reviews (20): Last reviewed commit: ["decodeEIAv1: メインフレームの境界外検出を追加 / GIF プロキシ..."](https://github.com/o-tr/imageslide-converter/commit/f56bc9bd848e928a8f3045fddde1ae1fa892364b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30380338)</sub>

<!-- /greptile_comment -->