### PR TITLE
feat(eia): implement animation container per PR#40 spec

### DIFF
--- a/docs/eia-v1-implementation-guide.md
+++ b/docs/eia-v1-implementation-guide.md
@@ -131,65 +131,114 @@ if (compressedPart.length > FileSizeLimit) {
 
 ### 4.1 エンコード
 
-アニメーションフレームはすべてのスライドデータの後にデータセクションへ追加され、スロット定義はマスターファイルの拡張オブジェクト（`e.a`）にJSON文字列として格納されます。
+アニメーションフレームはすべてのスライドデータの後にデータセクションへ追加され、フレームデータはマニフェストの `ac.pool` に集約されます。スライドの拡張オブジェクト（`e.a`）にはアニメーション参照配列（`EIAAnimationRef[]`）を**JSON文字列化せずそのまま**格納します。
 
 ```typescript
-// アニメーションフレームの圧縮（クロップフレームの例）
-let fileBufferLength = 0;
-const fileBuffer: Buffer[] = [];
-const parts: EIAFileV1CroppedPart[] = [];
+// フレームの重複排除とプール構築
+const pool: EIAAnimFramePoolItem[] = [];
+const poolDecodedBuffers: Buffer[] = [];
+const anims: EIAAnimation[] = [];
 
-for (const rect of frame.cropped.rects) {
-  fileBuffer.push(rect.buffer);
-  parts.push({
-    s: fileBufferLength,      // 展開バッファ内オフセット（0始まり）
-    l: rect.buffer.length,    // 非圧縮バイト長
-    x: rect.x, y: rect.y, w: rect.width, h: rect.height,
-  });
-  fileBufferLength += rect.buffer.length;
+for (const anim of animations) {
+  const seq: number[] = [];
+  const resolvedBuffers = new Map<number, Buffer>();
+  const framePoolIndices: number[] = [];
+  const newPoolFrames: RawImageObjV1Cropped[] = [];
+  const newDecodedBuffers: Buffer[] = [];
+
+  // Pass 1: すべてのフレームをデコードしプールインデックスを決定
+  for (let fi = 0; fi < anim.frames.length; fi++) {
+    const frame = anim.frames[fi];
+    const decoded = decodeAnimationFrame(frame, resolvedBuffers);
+    resolvedBuffers.set(fi, decoded);
+
+    const existing = findMatchingPoolIndex(decoded, poolDecodedBuffers, frameW, frameH);
+    if (existing >= 0) {
+      framePoolIndices.push(existing);
+    } else {
+      const localExisting = findMatchingPoolIndex(decoded, newDecodedBuffers, frameW, frameH);
+      if (localExisting >= 0) {
+        framePoolIndices.push(pool.length + localExisting);
+      } else {
+        framePoolIndices.push(pool.length + newDecodedBuffers.length);
+        newDecodedBuffers.push(decoded);
+        newPoolFrames.push(frame);
+      }
+    }
+  }
+
+  poolDecodedBuffers.push(...newDecodedBuffers);
+
+  // Pass 2: 新規プールエントリを圧縮
+  for (const frame of newPoolFrames) {
+    if (!frame.cropped) {
+      const compressed = lz4.compress(frame.buffer);
+      pool.push({ t: "m", f: format, w: frameW, h: frameH, s: bufferLength, l: compressed.length, u: frame.buffer.length });
+      bufferLength += compressed.length;
+    } else {
+      const basePoolIndex = framePoolIndices[frame.cropped.baseIndex];
+      const parts = buildParts(frame.cropped.rects);
+      const merged = Buffer.concat(frame.cropped.rects.map(r => r.buffer));
+      const compressed = lz4.compress(merged);
+      pool.push({ t: "c", f: format, w: frameW, h: frameH, b: basePoolIndex, s: bufferLength, l: compressed.length, u: merged.length, r: parts });
+      bufferLength += compressed.length;
+    }
+  }
+
+  anims.push({ id: animId, fps: anim.fps, seq: framePoolIndices });
+  slideRefs.push({ id: animId, x: anim.x, y: anim.y, w: anim.w, h: anim.h });
 }
 
-const mergedBuffer = Buffer.concat(fileBuffer);
-const compressed = lz4.compress(mergedBuffer);
-
-frameRefs.push({
-  t: "c",
-  s: bufferLength,            // データセクション内の圧縮空間オフセット
-  l: compressed.length,
-  u: mergedBuffer.length,
-  r: parts,                   // parts[i].s は展開バッファ内オフセット
-  b: frame.cropped.baseIndex,
-});
-bufferLength += compressed.length;
+// e.a に参照配列をそのまま格納（JSON.stringify しない）
+file.e = { ...file.e, a: slideRefs };
+manifest.ac = { pool, anims };
+manifest.f.push("Feature:animation");
 ```
 
 ### 4.2 デコード
 
+アニメーションデータは `manifest.ac` からデコードします。プール内のフレームは依存関係を解決しながら再帰的にデコードします。
+
 ```typescript
-// フレームインデックス計算
-const frameIndex = Math.floor((Time.now - startTime) * fps) % frameCount;
+// フレームプールのデコード（メモ化 + 深さ制限）
+const decodePoolFrame = (pool, binarySection, index, depth, memo) => {
+  if (depth > 64) throw new Error("Pool reference depth exceeded");
+  if (memo.has(index)) return memo.get(index);
 
-// マスターフレーム
-if (frame.t === "m") {
-  const compressed = dataSection.slice(frame.s, frame.s + frame.l);
-  frameData = lz4.decompress(compressed, frame.u);
+  const item = pool[index];
+  const compressed = binarySection.slice(item.s, item.s + item.l);
+  const decompressed = lz4.decompress(compressed, item.u);
+
+  let result;
+  if (item.t === "m") {
+    result = decompressed;
+  } else {
+    const base = decodePoolFrame(pool, binarySection, item.b, depth + 1, memo);
+    const copied = new Uint8Array(base); // ベースをコピー（直接変更禁止）
+    result = applyRects(copied, decompressed, item.r, item.w, item.f);
+  }
+  memo.set(index, result);
+  return result;
+};
+
+// すべてのプールフレームを事前デコード
+const poolDecoded = new Map();
+for (let i = 0; i < manifest.ac.pool.length; i++) {
+  decodePoolFrame(manifest.ac.pool, binarySection, i, 0, poolDecoded);
 }
 
-// クロップ（デルタ）フレーム（疑似コード）
-// 参考実装: src/lib/slidePreview/decodeEIAv1.ts のモジュール内関数 `applyRects`
-if (frame.t === "c") {
-  const compressed = dataSection.slice(frame.s, frame.s + frame.l);
-  const delta = lz4.decompress(compressed, frame.u);
-  // baseFrameData をコピーし、frame.r の各パーツを delta バッファから上書き合成する。
-  // part.s は delta バッファ内のオフセット（圧縮空間ではない）。
-  // fw / format はアニメーションスロットの fw（フレーム幅）/ f（テクスチャフォーマット）。
-  frameData = applyRects(baseFrameData, delta, frame.r, fw, format);
-}
+// フレームインデックス計算（Unixエポック基点で同期再生）
+const frameIndex = Math.floor((Date.now() / 1000) * fps) % seq.length;
+const poolIdx = anim.seq[frameIndex];
+const frameData = poolDecoded.get(poolIdx);
+
+// 表示スロットに配置（フレームサイズと表示サイズが異なる場合はスケール）
+// drawImage を使用してスケーリング描画
+ctx.drawImage(
+  frameImage,
+  ref.x, ref.y, ref.w, ref.h,  // 表示スロット
+);
 ```
-
-### 4.3 フレームサイズ拡張
-
-アニメーションフレームの格納サイズ（`fw`/`fh`）が表示スロットサイズ（`w`/`h`）と異なる場合は、スロットメタデータに `fw`/`fh` を含め、マニフェストの `f` 配列に `"Feature:animation-frame-size"` を追加しなければなりません（MUST）。`manifest.v` は常に `1` です。
 
 ## 5. フォーマット互換性
 

--- a/docs/eia-v1-implementation-guide.md
+++ b/docs/eia-v1-implementation-guide.md
@@ -199,6 +199,9 @@ manifest.f.push("Feature:animation");
 
 アニメーションデータは `manifest.ac` からデコードします。プール内のフレームは依存関係を解決しながら再帰的にデコードします。
 
+> **実装上の注意（`manifest.c === "lz4-base64"`）**  
+> 現在の `decodeEIAv1` 実装では、`manifest.c` が `"lz4-base64"` の場合は `binarySection` が存在しないため、`manifest.ac` があっても `decodePoolFrame` を呼ばず、`lz4` ベースのプール復元（`lz4.decompress`）を実行しません。結果として、仕様文上は `manifest.ac` から復元可能でも、実行時にはプール化アニメーションのデコードを意図的にスキップします。
+
 ```typescript
 // フレームプールのデコード（メモ化 + 深さ制限）
 const decodePoolFrame = (pool, binarySection, index, depth, memo) => {

--- a/docs/en/eia-v1-implementation-guide.md
+++ b/docs/en/eia-v1-implementation-guide.md
@@ -131,65 +131,110 @@ Provide compression ratio estimates for different scenarios:
 
 ### 4.1 Encoding
 
-Animation frames are appended to the data section after all slide data. The slot definition is stored as a JSON string in the master file's extension object (`e.a`).
+Animation frames are appended to the data section after all slide data. Frame data is aggregated into `ac.pool` at the manifest top level. The slide's extension object (`e.a`) stores the animation reference array (`EIAAnimationRef[]`) **natively without JSON.stringify**.
 
 ```typescript
-// Encoding a cropped animation frame
-let fileBufferLength = 0;
-const fileBuffer: Buffer[] = [];
-const parts: EIAFileV1CroppedPart[] = [];
+// Frame deduplication and pool construction
+const pool: EIAAnimFramePoolItem[] = [];
+const poolDecodedBuffers: Buffer[] = [];
+const anims: EIAAnimation[] = [];
 
-for (const rect of frame.cropped.rects) {
-  fileBuffer.push(rect.buffer);
-  parts.push({
-    s: fileBufferLength,      // decompressed-buffer offset (starts at 0)
-    l: rect.buffer.length,    // uncompressed byte length
-    x: rect.x, y: rect.y, w: rect.width, h: rect.height,
-  });
-  fileBufferLength += rect.buffer.length;
+for (const anim of animations) {
+  const seq: number[] = [];
+  const resolvedBuffers = new Map<number, Buffer>();
+  const framePoolIndices: number[] = [];
+  const newPoolFrames: RawImageObjV1Cropped[] = [];
+  const newDecodedBuffers: Buffer[] = [];
+
+  // Pass 1: decode all frames and assign pool indices (with dedup)
+  for (let fi = 0; fi < anim.frames.length; fi++) {
+    const frame = anim.frames[fi];
+    const decoded = decodeAnimationFrame(frame, resolvedBuffers);
+    resolvedBuffers.set(fi, decoded);
+
+    const existing = findMatchingPoolIndex(decoded, poolDecodedBuffers, frameW, frameH);
+    if (existing >= 0) {
+      framePoolIndices.push(existing);
+    } else {
+      const localExisting = findMatchingPoolIndex(decoded, newDecodedBuffers, frameW, frameH);
+      if (localExisting >= 0) {
+        framePoolIndices.push(pool.length + localExisting);
+      } else {
+        framePoolIndices.push(pool.length + newDecodedBuffers.length);
+        newDecodedBuffers.push(decoded);
+        newPoolFrames.push(frame);
+      }
+    }
+  }
+
+  poolDecodedBuffers.push(...newDecodedBuffers);
+
+  // Pass 2: compress new pool entries
+  for (const frame of newPoolFrames) {
+    if (!frame.cropped) {
+      const compressed = lz4.compress(frame.buffer);
+      pool.push({ t: "m", f: format, w: frameW, h: frameH, s: bufferLength, l: compressed.length, u: frame.buffer.length });
+      bufferLength += compressed.length;
+    } else {
+      const basePoolIndex = framePoolIndices[frame.cropped.baseIndex];
+      const parts = buildParts(frame.cropped.rects);
+      const merged = Buffer.concat(frame.cropped.rects.map(r => r.buffer));
+      const compressed = lz4.compress(merged);
+      pool.push({ t: "c", f: format, w: frameW, h: frameH, b: basePoolIndex, s: bufferLength, l: compressed.length, u: merged.length, r: parts });
+      bufferLength += compressed.length;
+    }
+  }
+
+  anims.push({ id: animId, fps: anim.fps, seq: framePoolIndices });
+  slideRefs.push({ id: animId, x: anim.x, y: anim.y, w: anim.w, h: anim.h });
 }
 
-const mergedBuffer = Buffer.concat(fileBuffer);
-const compressed = lz4.compress(mergedBuffer);
-
-frameRefs.push({
-  t: "c",
-  s: bufferLength,            // compressed-space offset in the data section
-  l: compressed.length,
-  u: mergedBuffer.length,
-  r: parts,                   // parts[i].s are decompressed-buffer offsets
-  b: frame.cropped.baseIndex,
-});
-bufferLength += compressed.length;
+// Store refs natively in e.a (do not JSON.stringify)
+file.e = { ...file.e, a: slideRefs };
+manifest.ac = { pool, anims };
+manifest.f.push("Feature:animation");
 ```
 
 ### 4.2 Decoding
 
+Animation data is decoded from `manifest.ac`. Pool frames are decoded recursively while resolving dependencies.
+
 ```typescript
-// Frame index calculation
-const frameIndex = Math.floor((Time.now - startTime) * fps) % frameCount;
+// Pool frame decoding (memoization + depth limit)
+const decodePoolFrame = (pool, binarySection, index, depth, memo) => {
+  if (depth > 64) throw new Error("Pool reference depth exceeded");
+  if (memo.has(index)) return memo.get(index);
 
-// Master frame
-if (frame.t === "m") {
-  const compressed = dataSection.slice(frame.s, frame.s + frame.l);
-  frameData = lz4.decompress(compressed, frame.u);
+  const item = pool[index];
+  const compressed = binarySection.slice(item.s, item.s + item.l);
+  const decompressed = lz4.decompress(compressed, item.u);
+
+  let result;
+  if (item.t === "m") {
+    result = decompressed;
+  } else {
+    const base = decodePoolFrame(pool, binarySection, item.b, depth + 1, memo);
+    const copied = new Uint8Array(base); // copy base (MUST NOT modify in place)
+    result = applyRects(copied, decompressed, item.r, item.w, item.f);
+  }
+  memo.set(index, result);
+  return result;
+};
+
+// Pre-decode all pool frames
+const poolDecoded = new Map();
+for (let i = 0; i < manifest.ac.pool.length; i++) {
+  decodePoolFrame(manifest.ac.pool, binarySection, i, 0, poolDecoded);
 }
 
-// Cropped (delta) frame (pseudo-code)
-// Reference implementation: the module-local `applyRects` in src/lib/slidePreview/decodeEIAv1.ts
-if (frame.t === "c") {
-  const compressed = dataSection.slice(frame.s, frame.s + frame.l);
-  const delta = lz4.decompress(compressed, frame.u);
-  // Copy baseFrameData and overwrite each part of `frame.r` from the delta buffer.
-  // part.s is an offset into the delta buffer (not compressed space).
-  // fw / format come from the animation slot's fw (frame width) / f (texture format).
-  frameData = applyRects(baseFrameData, delta, frame.r, fw, format);
-}
+// Frame index calculation (Unix epoch anchor for synchronized playback)
+const frameIndex = Math.floor((Date.now() / 1000) * fps) % seq.length;
+const poolIdx = anim.seq[frameIndex];
+const frameData = poolDecoded.get(poolIdx);
+
+// Render into display slot (scale if frame size differs from display size)
+ctx.drawImage(frameImage, ref.x, ref.y, ref.w, ref.h);
 ```
-
-### 4.3 Frame Size Extension
-
-When the stored frame dimensions (`fw`/`fh`) differ from the display slot dimensions (`w`/`h`), the slot metadata MUST include `fw`/`fh` and the manifest's `f` array MUST include `"Feature:animation-frame-size"`. `manifest.v` remains `1`.
 
 ## 5. Format Compatibility
 

--- a/docs/en/eia-v1-implementation-guide.md
+++ b/docs/en/eia-v1-implementation-guide.md
@@ -199,6 +199,9 @@ manifest.f.push("Feature:animation");
 
 Animation data is decoded from `manifest.ac`. Pool frames are decoded recursively while resolving dependencies.
 
+> **Implementation note (`manifest.c === "lz4-base64"`)**  
+> In the current `decodeEIAv1` runtime, when `manifest.c` is `"lz4-base64"` there is no binary section, so the code path that would call `decodePoolFrame` and run `lz4.decompress` for `manifest.ac.pool` is intentionally skipped. As a result, pooled animation frames in `manifest.ac` are not decoded at runtime under `lz4-base64`, even though the spec text describes decoding from `manifest.ac`.
+
 ```typescript
 // Pool frame decoding (memoization + depth limit)
 const decodePoolFrame = (pool, binarySection, index, depth, memo) => {

--- a/src/_types/eia/v1.ts
+++ b/src/_types/eia/v1.ts
@@ -6,51 +6,66 @@ export type EIAExtension = (typeof EIAExtensions)[number];
 
 export type EIAExtensionObject = {
   note?: string;
-  a?: string; // JSON string of EIAAnimationMeta[]
-} & { [key in EIAExtension]?: string };
-
-export type EIAAnimationMeta = {
-  x: number; // pixel X on base image
-  y: number; // pixel Y on base image
-  w: number; // display pixel width
-  h: number; // display pixel height
-  fw?: number; // stored frame pixel width (defaults to w)
-  fh?: number; // stored frame pixel height (defaults to h)
-  fps: number; // frame rate
-  f: TTextureFormat; // frame format
-  frames: EIAAnimationFrameRef[];
+  a?: EIAAnimationRef[];
+  [key: string]: string | EIAAnimationRef[] | undefined;
 };
 
-export type EIAAnimationFrameRef =
-  | EIAAnimationFrameRefMaster
-  | EIAAnimationFrameRefCropped;
-
-export type EIAAnimationFrameRefMaster = {
-  t: "m"; // master (full frame)
-  s: number; // start offset in data section
-  l: number; // compressed length
-  u: number; // uncompressed size
+export type EIAAnimationContainer = {
+  pool: EIAAnimFramePoolItem[];
+  anims: EIAAnimation[];
 };
 
-export type EIAAnimationFrameRefCropped = {
-  t: "c"; // cropped (diff frame)
-  b: number; // base frame index within this animation's frames array
-  s: number; // start offset in data section
-  l: number; // compressed length
-  u: number; // uncompressed size
-  r: EIAFileV1CroppedPart[]; // changed rects
+export type EIAAnimFramePoolItem =
+  | EIAAnimFramePoolItemMaster
+  | EIAAnimFramePoolItemCropped;
+
+export type EIAAnimFramePoolItemMaster = {
+  t: "m";
+  f: TTextureFormat;
+  w: number;
+  h: number;
+  s: number;
+  l: number;
+  u: number;
+};
+
+export type EIAAnimFramePoolItemCropped = {
+  t: "c";
+  f: TTextureFormat;
+  w: number;
+  h: number;
+  b: number;
+  s: number;
+  l: number;
+  u: number;
+  r: EIAFileV1CroppedPart[];
+};
+
+export type EIAAnimation = {
+  id: string;
+  fps: number;
+  seq: number[];
+};
+
+export type EIAAnimationRef = {
+  id: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
 };
 
 export type EIACompressionMethod = "lz4" | "lz4-base64";
 
 export type EIAManifestV1 = {
-  t: "eia"; //type
-  c: EIACompressionMethod; //compressor
-  v: 1; //version
-  f: string[]; //features
-  e: EIAExtension[]; //extensions
-  i: EIAFileV1[]; //items
+  t: "eia";
+  c: EIACompressionMethod;
+  v: 1;
+  f: string[];
+  e: EIAExtension[];
+  i: EIAFileV1[];
   m?: EIASignageManifest;
+  ac?: EIAAnimationContainer;
 };
 
 export type EIASignageManifest = {
@@ -58,39 +73,39 @@ export type EIASignageManifest = {
 };
 
 export type EIASignageItem = {
-  f: string; // file name
-  t: string; // transition
-  d: number; // duration
+  f: string;
+  t: string;
+  d: number;
 };
 
 export type EIAFileV1 = EIAFileV1Master | EIAFileV1Cropped;
 
 type EIAFileV1Base = {
-  n: string; //name
-  f: TTextureFormat; //format
-  w: number; //width
-  h: number; //height
-  s: number; //start
-  l: number; //length
-  u: number; //uncompressed size
-  e?: EIAExtensionObject; //extensions
+  n: string;
+  f: TTextureFormat;
+  w: number;
+  h: number;
+  s: number;
+  l: number;
+  u: number;
+  e?: EIAExtensionObject;
 };
 
 export type EIAFileV1Master = EIAFileV1Base & {
-  t: "m"; //type: master
+  t: "m";
 };
 
 export type EIAFileV1Cropped = EIAFileV1Base & {
-  t: "c"; //type: cropped
-  b: string; // base file name
-  r: EIAFileV1CroppedPart[]; //rects
+  t: "c";
+  b: string;
+  r: EIAFileV1CroppedPart[];
 };
 
 export type EIAFileV1CroppedPart = {
   x: number;
   y: number;
-  w: number; //width
-  h: number; //height
-  s: number; //start (in file)
-  l: number; //length
+  w: number;
+  h: number;
+  s: number;
+  l: number;
 };

--- a/src/_types/eia/v1.ts
+++ b/src/_types/eia/v1.ts
@@ -7,7 +7,6 @@ export type EIAExtension = (typeof EIAExtensions)[number];
 export type EIAExtensionObject = {
   note?: string;
   a?: EIAAnimationRef[];
-  [key: string]: string | EIAAnimationRef[] | undefined;
 };
 
 export type EIAAnimationContainer = {

--- a/src/lib/eia/compressEIAv1.ts
+++ b/src/lib/eia/compressEIAv1.ts
@@ -293,6 +293,8 @@ const compressEIAv1Part = async (
             buffer.push(compressed);
             animBufferLength += compressed.length;
           } else {
+            // baseIndex is an index into anim.frames (not newPoolFrames), and
+            // framePoolIndices is built with the same anim.frames indexing.
             const basePoolIndex = framePoolIndices[frame.cropped.baseIndex];
             const parts: EIAFileV1CroppedPart[] = [];
             let fileBufferLength = 0;

--- a/src/lib/eia/compressEIAv1.ts
+++ b/src/lib/eia/compressEIAv1.ts
@@ -15,8 +15,14 @@ import { IMAGE_DIFF_THRESHOLD } from "@/const/config";
 import { FileSizeLimit } from "@/const/convert";
 import lz4 from "lz4js";
 
-const ACTUAL_DIFF_THRESHOLD = IMAGE_DIFF_THRESHOLD * 3;
 const SIMILARITY_THRESHOLD_RATIO = 0.005;
+const IMAGE_FORMAT_RGBA32 = "RGBA32";
+
+const getBytesPerPixel = (format: string): number => {
+  if (format === IMAGE_FORMAT_RGBA32) return 4;
+  if (format.startsWith("RGB24")) return 3;
+  throw new Error(`Unsupported animation format: "${format}"`);
+};
 
 export const compressEIAv1 = async (
   data: RawImageObjV1Cropped[],
@@ -197,6 +203,7 @@ const compressEIAv1Part = async (
 
         if (anim.frames.length === 0) continue;
         usedFormats.add(anim.format);
+        const bpp = getBytesPerPixel(anim.format);
 
         const frameW = anim.frames[0].rect.width;
         const frameH = anim.frames[0].rect.height;
@@ -220,17 +227,28 @@ const compressEIAv1Part = async (
         const framePoolIndices: number[] = [];
         const newPoolFrames: RawImageObjV1Cropped[] = [];
         const newDecodedBuffers: Buffer[] = [];
+        const cropBaseIndices = new Set<number>();
+
+        for (const frame of anim.frames) {
+          if (frame.cropped) {
+            cropBaseIndices.add(frame.cropped.baseIndex);
+          }
+        }
 
         for (let fi = 0; fi < anim.frames.length; fi++) {
           const frame = anim.frames[fi];
-          const decoded = decodeAnimationFrame(frame, resolvedBuffers);
+          const decoded = decodeAnimationFrame(frame, resolvedBuffers, bpp);
           resolvedBuffers.set(fi, decoded);
+          const requireExactMatch =
+            frame.cropped !== undefined || cropBaseIndices.has(fi);
 
           const existing = findMatchingPoolIndex(
             decoded,
             poolDecodedBuffers,
             frameW,
             frameH,
+            bpp,
+            requireExactMatch,
           );
           if (existing >= 0) {
             framePoolIndices.push(existing);
@@ -242,6 +260,8 @@ const compressEIAv1Part = async (
             newDecodedBuffers,
             frameW,
             frameH,
+            bpp,
+            requireExactMatch,
           );
           if (localExisting >= 0) {
             framePoolIndices.push(pool.length + localExisting);
@@ -369,6 +389,7 @@ const compressEIAv1Part = async (
 const decodeAnimationFrame = (
   frame: RawImageObjV1Cropped,
   resolvedBuffers: Map<number, Buffer>,
+  bpp: number,
 ): Buffer => {
   if (!frame.cropped) return frame.buffer;
   const base = resolvedBuffers.get(frame.cropped.baseIndex);
@@ -380,9 +401,9 @@ const decodeAnimationFrame = (
   const result = Buffer.from(base);
   for (const rect of frame.cropped.rects) {
     for (let j = 0; j < rect.height; j++) {
-      const srcStart = j * rect.width * 3;
-      const dstStart = ((rect.y + j) * frame.rect.width + rect.x) * 3;
-      rect.buffer.copy(result, dstStart, srcStart, srcStart + rect.width * 3);
+      const srcStart = j * rect.width * bpp;
+      const dstStart = ((rect.y + j) * frame.rect.width + rect.x) * bpp;
+      rect.buffer.copy(result, dstStart, srcStart, srcStart + rect.width * bpp);
     }
   }
   return result;
@@ -393,15 +414,21 @@ const findMatchingPoolIndex = (
   poolBuffers: Buffer[],
   width: number,
   height: number,
+  bpp: number,
+  requireExactMatch: boolean,
 ): number => {
+  const expectedLength = width * height * bpp;
+  if (decoded.length !== expectedLength) return -1;
+  const threshold = Math.max(
+    1,
+    Math.floor(width * height * SIMILARITY_THRESHOLD_RATIO),
+  );
   for (let i = 0; i < poolBuffers.length; i++) {
-    if (poolBuffers[i].length !== decoded.length) continue;
-    const diff = computeDiffMask(poolBuffers[i], decoded, width, height);
+    if (poolBuffers[i].length !== expectedLength) continue;
+    if (poolBuffers[i].equals(decoded)) return i;
+    if (requireExactMatch) continue;
+    const diff = computeDiffMask(poolBuffers[i], decoded, width, height, bpp);
     const diffCount = countDiffPixels(diff);
-    const threshold = Math.max(
-      1,
-      Math.floor(width * height * SIMILARITY_THRESHOLD_RATIO),
-    );
     if (diffCount <= threshold) return i;
   }
   return -1;
@@ -412,16 +439,18 @@ const computeDiffMask = (
   b: Buffer,
   width: number,
   height: number,
+  bpp: number,
 ): Uint8Array => {
   const result = new Uint8Array(width * height);
+  const actualDiffThreshold = IMAGE_DIFF_THRESHOLD * bpp;
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      const idx = (y * width + x) * 3;
-      const diff =
-        Math.abs(a[idx] - b[idx]) +
-        Math.abs(a[idx + 1] - b[idx + 1]) +
-        Math.abs(a[idx + 2] - b[idx + 2]);
-      result[y * width + x] = diff > ACTUAL_DIFF_THRESHOLD ? 1 : 0;
+      const idx = (y * width + x) * bpp;
+      let diff = 0;
+      for (let channel = 0; channel < bpp; channel++) {
+        diff += Math.abs(a[idx + channel] - b[idx + channel]);
+      }
+      result[y * width + x] = diff > actualDiffThreshold ? 1 : 0;
     }
   }
   return result;

--- a/src/lib/eia/compressEIAv1.ts
+++ b/src/lib/eia/compressEIAv1.ts
@@ -24,6 +24,8 @@ const getBytesPerPixel = (format: string): number => {
   throw new Error(`Unsupported animation format: "${format}"`);
 };
 
+type FrameDimensions = { w: number; h: number };
+
 export const compressEIAv1 = async (
   data: RawImageObjV1Cropped[],
   signage?: EIASignageManifest,
@@ -191,6 +193,7 @@ const compressEIAv1Part = async (
   if (animationMap) {
     const pool: EIAAnimFramePoolItem[] = [];
     const poolDecodedBuffers: Buffer[] = [];
+    const poolDecodedDimensions: FrameDimensions[] = [];
     const anims: EIAAnimation[] = [];
     let animBufferLength = bufferLength;
 
@@ -248,6 +251,7 @@ const compressEIAv1Part = async (
             frameH,
             bpp,
             requireExactMatch,
+            poolDecodedDimensions,
           );
           if (existing >= 0) {
             framePoolIndices.push(existing);
@@ -273,6 +277,9 @@ const compressEIAv1Part = async (
 
         // Register decoded buffers for global dedup
         poolDecodedBuffers.push(...newDecodedBuffers);
+        for (let i = 0; i < newDecodedBuffers.length; i++) {
+          poolDecodedDimensions.push({ w: frameW, h: frameH });
+        }
 
         // Pass 2: compress new pool entries
         for (let ni = 0; ni < newPoolFrames.length; ni++) {
@@ -294,7 +301,20 @@ const compressEIAv1Part = async (
           } else {
             // baseIndex is an index into anim.frames (not newPoolFrames), and
             // framePoolIndices is built with the same anim.frames indexing.
+            if (
+              frame.cropped.baseIndex < 0 ||
+              frame.cropped.baseIndex >= framePoolIndices.length
+            ) {
+              throw new Error(
+                `Invalid animation base frame index ${frame.cropped.baseIndex} at slide ${slideIndex}, animation ${animIndex}`,
+              );
+            }
             const basePoolIndex = framePoolIndices[frame.cropped.baseIndex];
+            if (basePoolIndex === undefined) {
+              throw new Error(
+                `Unresolved animation base frame index ${frame.cropped.baseIndex} at slide ${slideIndex}, animation ${animIndex}`,
+              );
+            }
             const parts: EIAFileV1CroppedPart[] = [];
             let fileBufferLength = 0;
             const fileBuffer: Buffer[] = [];
@@ -414,6 +434,7 @@ const findMatchingPoolIndex = (
   height: number,
   bpp: number,
   requireExactMatch: boolean,
+  poolDimensions?: FrameDimensions[],
 ): number => {
   const expectedLength = width * height * bpp;
   if (decoded.length !== expectedLength) return -1;
@@ -423,6 +444,12 @@ const findMatchingPoolIndex = (
   );
   for (let i = 0; i < poolBuffers.length; i++) {
     if (poolBuffers[i].length !== expectedLength) continue;
+    const candidateDimensions = poolDimensions?.[i];
+    if (candidateDimensions) {
+      if (candidateDimensions.w !== width || candidateDimensions.h !== height) {
+        continue;
+      }
+    }
     if (poolBuffers[i].equals(decoded)) return i;
     if (requireExactMatch) continue;
     const diff = computeDiffMask(poolBuffers[i], decoded, width, height, bpp);

--- a/src/lib/eia/compressEIAv1.ts
+++ b/src/lib/eia/compressEIAv1.ts
@@ -1,15 +1,22 @@
 import type { RawAnimationData } from "@/_types/eia/rawAnimationData";
 import type {
-  EIAAnimationFrameRef,
-  EIAAnimationMeta,
+  EIAAnimFramePoolItem,
+  EIAAnimFramePoolItemCropped,
+  EIAAnimation,
+  EIAAnimationContainer,
+  EIAAnimationRef,
   EIAFileV1,
   EIAFileV1CroppedPart,
   EIAManifestV1,
   EIASignageManifest,
 } from "@/_types/eia/v1";
 import type { RawImageObjV1Cropped } from "@/_types/text-zip/v1";
+import { IMAGE_DIFF_THRESHOLD } from "@/const/config";
 import { FileSizeLimit } from "@/const/convert";
 import lz4 from "lz4js";
+
+const ACTUAL_DIFF_THRESHOLD = IMAGE_DIFF_THRESHOLD * 3;
+const SIMILARITY_THRESHOLD_RATIO = 0.005;
 
 export const compressEIAv1 = async (
   data: RawImageObjV1Cropped[],
@@ -111,11 +118,8 @@ const compressEIAv1Part = async (
   const buffer: Buffer[] = [];
   let bufferLength = 0;
 
-  // Track animation metadata per slide index
-  const slideAnimMeta = new Map<number, string>();
-
   for (const image of data) {
-    const ext: { note?: string; a?: string } = {};
+    const ext: { note?: string } = {};
     if (image.note) ext.note = image.note;
 
     if (!image.cropped) {
@@ -174,49 +178,106 @@ const compressEIAv1Part = async (
     bufferLength += compressed.length;
   }
 
-  // Append animation frames to data section (after all slide data)
-  if (animationMap) {
-    for (const [slideIndex, anims] of animationMap) {
-      const animMetas: EIAAnimationMeta[] = [];
+  // Encode animations into a global pool + container
+  let ac: EIAAnimationContainer | undefined;
+  const slideAnimRefs = new Map<number, EIAAnimationRef[]>();
 
-      for (const [animIndex, anim] of anims.entries()) {
-        const frameRefs: EIAAnimationFrameRef[] = [];
-        let hasCroppedFrames = false;
+  if (animationMap) {
+    const pool: EIAAnimFramePoolItem[] = [];
+    const poolDecodedBuffers: Buffer[] = [];
+    const anims: EIAAnimation[] = [];
+    let animBufferLength = bufferLength;
+
+    for (const [slideIndex, animsData] of animationMap) {
+      const refs: EIAAnimationRef[] = [];
+
+      for (const [animIndex, anim] of animsData.entries()) {
+        const animId = `anim_${slideIndex}_${animIndex}`;
+        const seq: number[] = [];
+
         if (anim.frames.length === 0) continue;
         usedFormats.add(anim.format);
-        const frameWidth = anim.frames[0].rect.width;
-        const frameHeight = anim.frames[0].rect.height;
+
+        const frameW = anim.frames[0].rect.width;
+        const frameH = anim.frames[0].rect.height;
+
+        // Validation
         for (const [frameIndex, frame] of anim.frames.entries()) {
           if (frame.format !== anim.format) {
             throw new Error(
               `Animation format mismatch at slide ${slideIndex}, animation ${animIndex}, frame ${frameIndex}: expected "${anim.format}", got "${frame.format}"`,
             );
           }
-          if (
-            frame.rect.width !== frameWidth ||
-            frame.rect.height !== frameHeight
-          ) {
+          if (frame.rect.width !== frameW || frame.rect.height !== frameH) {
             throw new Error(
-              `Animation frame size mismatch at slide ${slideIndex}, animation ${animIndex}, frame ${frameIndex}: expected ${frameWidth}x${frameHeight}, got ${frame.rect.width}x${frame.rect.height}`,
+              `Animation frame size mismatch at slide ${slideIndex}, animation ${animIndex}, frame ${frameIndex}: expected ${frameW}x${frameH}, got ${frame.rect.width}x${frame.rect.height}`,
             );
           }
+        }
+
+        // Pass 1: decode all frames and assign pool indices (with dedup)
+        const resolvedBuffers = new Map<number, Buffer>();
+        const framePoolIndices: number[] = [];
+        const newPoolFrames: RawImageObjV1Cropped[] = [];
+        const newDecodedBuffers: Buffer[] = [];
+
+        for (let fi = 0; fi < anim.frames.length; fi++) {
+          const frame = anim.frames[fi];
+          const decoded = decodeAnimationFrame(frame, resolvedBuffers);
+          resolvedBuffers.set(fi, decoded);
+
+          const existing = findMatchingPoolIndex(
+            decoded,
+            poolDecodedBuffers,
+            frameW,
+            frameH,
+          );
+          if (existing >= 0) {
+            framePoolIndices.push(existing);
+            continue;
+          }
+
+          const localExisting = findMatchingPoolIndex(
+            decoded,
+            newDecodedBuffers,
+            frameW,
+            frameH,
+          );
+          if (localExisting >= 0) {
+            framePoolIndices.push(pool.length + localExisting);
+          } else {
+            framePoolIndices.push(pool.length + newDecodedBuffers.length);
+            newDecodedBuffers.push(decoded);
+            newPoolFrames.push(frame);
+          }
+        }
+
+        // Register decoded buffers for global dedup
+        poolDecodedBuffers.push(...newDecodedBuffers);
+
+        // Pass 2: compress new pool entries
+        for (let ni = 0; ni < newPoolFrames.length; ni++) {
+          const frame = newPoolFrames[ni];
+
           if (!frame.cropped) {
-            // Master frame: store full buffer
             const compressed = Buffer.from(lz4.compress(frame.buffer));
-            buffer.push(compressed);
-            frameRefs.push({
+            pool.push({
               t: "m",
-              s: bufferLength,
+              f: anim.format,
+              w: frameW,
+              h: frameH,
+              s: animBufferLength,
               l: compressed.length,
               u: frame.buffer.length,
             });
-            bufferLength += compressed.length;
+            buffer.push(compressed);
+            animBufferLength += compressed.length;
           } else {
-            // Cropped frame: concatenate rect buffers, then compress
-            hasCroppedFrames = true;
+            const basePoolIndex = framePoolIndices[frame.cropped.baseIndex];
+            const parts: EIAFileV1CroppedPart[] = [];
             let fileBufferLength = 0;
             const fileBuffer: Buffer[] = [];
-            const parts: EIAFileV1CroppedPart[] = [];
+
             for (const rect of frame.cropped.rects) {
               fileBuffer.push(rect.buffer);
               parts.push({
@@ -229,51 +290,51 @@ const compressEIAv1Part = async (
               });
               fileBufferLength += rect.buffer.length;
             }
+
             const mergedBuffer = Buffer.concat(fileBuffer);
             const compressed = Buffer.from(lz4.compress(mergedBuffer));
-            buffer.push(compressed);
-            frameRefs.push({
+            const poolItem: EIAAnimFramePoolItemCropped = {
               t: "c",
-              b: frame.cropped.baseIndex,
-              r: parts,
-              s: bufferLength,
+              f: anim.format,
+              w: frameW,
+              h: frameH,
+              b: basePoolIndex,
+              s: animBufferLength,
               l: compressed.length,
               u: mergedBuffer.length,
-            });
-            bufferLength += compressed.length;
+              r: parts,
+            };
+            pool.push(poolItem);
+            buffer.push(compressed);
+            animBufferLength += compressed.length;
           }
         }
-        if (hasCroppedFrames) {
-          usedFeatures.add("Feature:animation-crop");
+
+        // Build seq
+        for (let fi = 0; fi < anim.frames.length; fi++) {
+          seq.push(framePoolIndices[fi]);
         }
 
-        const animMeta: EIAAnimationMeta = {
-          x: anim.x,
-          y: anim.y,
-          w: anim.w,
-          h: anim.h,
-          fps: anim.fps,
-          f: anim.format,
-          frames: frameRefs,
-        };
-        if (frameWidth !== anim.w || frameHeight !== anim.h) {
-          animMeta.fw = frameWidth;
-          animMeta.fh = frameHeight;
-          usedFeatures.add("Feature:animation-frame-size");
-        }
-        animMetas.push(animMeta);
+        anims.push({ id: animId, fps: anim.fps, seq });
+        refs.push({ id: animId, x: anim.x, y: anim.y, w: anim.w, h: anim.h });
       }
 
-      slideAnimMeta.set(slideIndex, JSON.stringify(animMetas));
+      if (refs.length > 0) {
+        slideAnimRefs.set(slideIndex, refs);
+      }
+    }
+
+    if (pool.length > 0 && anims.length > 0) {
+      ac = { pool, anims };
       usedFeatures.add("Feature:animation");
     }
 
-    // Attach animation metadata to corresponding slide items
+    // Attach animation refs to corresponding slide items
     for (const file of files) {
       const index = Number(file.n);
-      const animJson = slideAnimMeta.get(index);
-      if (animJson) {
-        file.e = { ...file.e, a: animJson };
+      const refs = slideAnimRefs.get(index);
+      if (refs) {
+        file.e = { ...file.e, a: refs };
       }
     }
   }
@@ -294,6 +355,7 @@ const compressEIAv1Part = async (
     ],
     i: files,
     m: signage,
+    ac,
   };
 
   const encodedBuffer = Buffer.concat([
@@ -302,4 +364,73 @@ const compressEIAv1Part = async (
   ]);
 
   return encodedBuffer;
+};
+
+const decodeAnimationFrame = (
+  frame: RawImageObjV1Cropped,
+  resolvedBuffers: Map<number, Buffer>,
+): Buffer => {
+  if (!frame.cropped) return frame.buffer;
+  const base = resolvedBuffers.get(frame.cropped.baseIndex);
+  if (!base) {
+    throw new Error(
+      `Base frame ${frame.cropped.baseIndex} not found for animation frame`,
+    );
+  }
+  const result = Buffer.from(base);
+  for (const rect of frame.cropped.rects) {
+    for (let j = 0; j < rect.height; j++) {
+      const srcStart = j * rect.width * 3;
+      const dstStart = ((rect.y + j) * frame.rect.width + rect.x) * 3;
+      rect.buffer.copy(result, dstStart, srcStart, srcStart + rect.width * 3);
+    }
+  }
+  return result;
+};
+
+const findMatchingPoolIndex = (
+  decoded: Buffer,
+  poolBuffers: Buffer[],
+  width: number,
+  height: number,
+): number => {
+  for (let i = 0; i < poolBuffers.length; i++) {
+    if (poolBuffers[i].length !== decoded.length) continue;
+    const diff = computeDiffMask(poolBuffers[i], decoded, width, height);
+    const diffCount = countDiffPixels(diff);
+    const threshold = Math.max(
+      1,
+      Math.floor(width * height * SIMILARITY_THRESHOLD_RATIO),
+    );
+    if (diffCount <= threshold) return i;
+  }
+  return -1;
+};
+
+const computeDiffMask = (
+  a: Buffer,
+  b: Buffer,
+  width: number,
+  height: number,
+): Uint8Array => {
+  const result = new Uint8Array(width * height);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 3;
+      const diff =
+        Math.abs(a[idx] - b[idx]) +
+        Math.abs(a[idx + 1] - b[idx + 1]) +
+        Math.abs(a[idx + 2] - b[idx + 2]);
+      result[y * width + x] = diff > ACTUAL_DIFF_THRESHOLD ? 1 : 0;
+    }
+  }
+  return result;
+};
+
+const countDiffPixels = (diff: Uint8Array): number => {
+  let count = 0;
+  for (let i = 0; i < diff.length; i++) {
+    if (diff[i] !== 0) count++;
+  }
+  return count;
 };

--- a/src/lib/eia/compressEIAv1.ts
+++ b/src/lib/eia/compressEIAv1.ts
@@ -199,7 +199,6 @@ const compressEIAv1Part = async (
 
       for (const [animIndex, anim] of animsData.entries()) {
         const animId = `anim_${slideIndex}_${animIndex}`;
-        const seq: number[] = [];
 
         if (anim.frames.length === 0) continue;
         usedFormats.add(anim.format);
@@ -332,10 +331,7 @@ const compressEIAv1Part = async (
           }
         }
 
-        // Build seq
-        for (let fi = 0; fi < anim.frames.length; fi++) {
-          seq.push(framePoolIndices[fi]);
-        }
+        const seq = framePoolIndices.slice();
 
         anims.push({ id: animId, fps: anim.fps, seq });
         refs.push({ id: animId, x: anim.x, y: anim.y, w: anim.w, h: anim.h });

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -612,7 +612,7 @@ export const extractGifAnimations = async (
           fps: previewFps,
           fpsOverride: Math.min(5, previewFps),
           frames,
-        } as SelectedFileAnimation;
+        } satisfies SelectedFileAnimation;
       } catch (e) {
         console.warn("Failed to build composed GIF frames:", e);
         return null;

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -612,13 +612,13 @@ export const extractGifAnimations = async (
           fps: previewFps,
           fpsOverride: Math.min(5, previewFps),
           frames,
-        } satisfies SelectedFileAnimation;
+        } as SelectedFileAnimation;
       } catch (e) {
         console.warn("Failed to build composed GIF frames:", e);
         return null;
       }
     })
-    .filter((r): r is SelectedFileAnimation => r !== null);
+    .filter((r): r is SelectedFileAnimation => !!r);
 
   return results;
 };

--- a/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
+++ b/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
@@ -1,7 +1,7 @@
 import type { RawAnimationData } from "@/_types/eia/rawAnimationData";
 import type { EIASignageManifest } from "@/_types/eia/v1";
 import type { SelectedFile } from "@/_types/file-picker";
-import type { RawImageObjV1 } from "@/_types/text-zip/v1";
+import type { RawImageObjV1, RawImageObjV1Cropped } from "@/_types/text-zip/v1";
 import { IMAGE_FORMAT_RGB24 } from "@/const/imageFormat";
 import { canvas2rgb24 } from "@/lib/canvas2rawImage/canvas2rgb24";
 import { compressEIAv1 } from "@/lib/eia/compressEIAv1";
@@ -36,6 +36,9 @@ export const selectedFiles2EIAv1RGB24Cropped = async (
   if (!signage) {
     // Extract animation data per slide (signage exports intentionally omit animations)
     const extractedAnimationMap = new Map<number, RawAnimationData[]>();
+    // Cache crop results keyed by pre-crop frame buffers so identical GIFs
+    // across slides share the same cropped frames (and pool dedup works).
+    const animationCache = new Map<string, RawImageObjV1Cropped[]>();
     for (let i = 0; i < selectedFiles.length; i++) {
       const file = selectedFiles[i];
       if (!file.animations || file.animations.length === 0) continue;
@@ -47,12 +50,23 @@ export const selectedFiles2EIAv1RGB24Cropped = async (
           format: IMAGE_FORMAT_RGB24,
           buffer: Buffer.from(canvas2rgb24(frame)),
         }));
-        // Apply differential compression to animation frames
-        const croppedAnimFrames = cropImages(animRawImages, {
-          keyframeInterval,
-          parentSearchWindow: 5,
-          parentSearchTopK: 1,
+        // Build a lightweight hash from pre-crop buffers to detect identical GIFs
+        const hashParts = animRawImages.map((img) => {
+          const b = img.buffer;
+          return `${b.length}:${b[0]}:${b[Math.floor(b.length / 4)]}:${b[Math.floor(b.length / 2)]}:${b[Math.floor((b.length * 3) / 4)]}:${b[b.length - 1]}`;
         });
+        const animHash = hashParts.join("|");
+        const cachedFrames = animationCache.get(animHash);
+        const croppedAnimFrames =
+          cachedFrames ??
+          cropImages(animRawImages, {
+            keyframeInterval,
+            parentSearchWindow: 5,
+            parentSearchTopK: 1,
+          });
+        if (!cachedFrames) {
+          animationCache.set(animHash, croppedAnimFrames);
+        }
         return {
           x: anim.x,
           y: anim.y,

--- a/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
+++ b/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
@@ -8,33 +8,38 @@ import { compressEIAv1 } from "@/lib/eia/compressEIAv1";
 import { cropImages } from "../crop/cropImages";
 
 const keyframeInterval = 10;
-const FNV_OFFSET_BASIS_64 = 0xcbf29ce484222325n;
-const FNV_PRIME_64 = 0x100000001b3n;
-const FNV_MASK_64 = 0xffffffffffffffffn;
+const FNV_OFFSET_BASIS_32 = 0x811c9dc5;
+const FNV_PRIME_32 = 0x01000193;
 const textEncoder = new TextEncoder();
 
-const updateFNV1a64 = (hash: bigint, data: Uint8Array): bigint => {
-  let result = hash;
+const updateFNV1a32 = (hash: number, data: Uint8Array): number => {
+  let result = hash >>> 0;
   for (let i = 0; i < data.length; i++) {
-    result ^= BigInt(data[i]);
-    result = (result * FNV_PRIME_64) & FNV_MASK_64;
+    result ^= data[i];
+    result = Math.imul(result, FNV_PRIME_32) >>> 0;
   }
   return result;
 };
 
 const createAnimationCacheKey = (frames: RawImageObjV1[]): string => {
-  let hash = FNV_OFFSET_BASIS_64;
-  hash = updateFNV1a64(hash, textEncoder.encode(`${frames.length}|`));
+  // Dual 32-bit FNV-1a keeps full-content hashing deterministic while avoiding
+  // per-byte BigInt overhead on large animation buffers.
+  let hashA = FNV_OFFSET_BASIS_32;
+  let hashB = (FNV_OFFSET_BASIS_32 ^ 0x9e3779b9) >>> 0;
+  const updateBoth = (data: Uint8Array) => {
+    hashA = updateFNV1a32(hashA, data);
+    hashB = updateFNV1a32(hashB, data);
+  };
+  updateBoth(textEncoder.encode(`${frames.length}|`));
   for (const frame of frames) {
-    hash = updateFNV1a64(
-      hash,
+    updateBoth(
       textEncoder.encode(
         `${frame.rect.width}x${frame.rect.height}:${frame.format}:${frame.buffer.length}|`,
       ),
     );
-    hash = updateFNV1a64(hash, frame.buffer);
+    updateBoth(frame.buffer);
   }
-  return hash.toString(16).padStart(16, "0");
+  return `${hashA.toString(16).padStart(8, "0")}${hashB.toString(16).padStart(8, "0")}`;
 };
 
 export const selectedFiles2EIAv1RGB24Cropped = async (

--- a/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
+++ b/src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts
@@ -8,6 +8,34 @@ import { compressEIAv1 } from "@/lib/eia/compressEIAv1";
 import { cropImages } from "../crop/cropImages";
 
 const keyframeInterval = 10;
+const FNV_OFFSET_BASIS_64 = 0xcbf29ce484222325n;
+const FNV_PRIME_64 = 0x100000001b3n;
+const FNV_MASK_64 = 0xffffffffffffffffn;
+const textEncoder = new TextEncoder();
+
+const updateFNV1a64 = (hash: bigint, data: Uint8Array): bigint => {
+  let result = hash;
+  for (let i = 0; i < data.length; i++) {
+    result ^= BigInt(data[i]);
+    result = (result * FNV_PRIME_64) & FNV_MASK_64;
+  }
+  return result;
+};
+
+const createAnimationCacheKey = (frames: RawImageObjV1[]): string => {
+  let hash = FNV_OFFSET_BASIS_64;
+  hash = updateFNV1a64(hash, textEncoder.encode(`${frames.length}|`));
+  for (const frame of frames) {
+    hash = updateFNV1a64(
+      hash,
+      textEncoder.encode(
+        `${frame.rect.width}x${frame.rect.height}:${frame.format}:${frame.buffer.length}|`,
+      ),
+    );
+    hash = updateFNV1a64(hash, frame.buffer);
+  }
+  return hash.toString(16).padStart(16, "0");
+};
 
 export const selectedFiles2EIAv1RGB24Cropped = async (
   selectedFiles: SelectedFile[],
@@ -50,12 +78,7 @@ export const selectedFiles2EIAv1RGB24Cropped = async (
           format: IMAGE_FORMAT_RGB24,
           buffer: Buffer.from(canvas2rgb24(frame)),
         }));
-        // Build a lightweight hash from pre-crop buffers to detect identical GIFs
-        const hashParts = animRawImages.map((img) => {
-          const b = img.buffer;
-          return `${b.length}:${b[0]}:${b[Math.floor(b.length / 4)]}:${b[Math.floor(b.length / 2)]}:${b[Math.floor((b.length * 3) / 4)]}:${b[b.length - 1]}`;
-        });
-        const animHash = hashParts.join("|");
+        const animHash = createAnimationCacheKey(animRawImages);
         const cachedFrames = animationCache.get(animHash);
         const croppedAnimFrames =
           cachedFrames ??

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -1,6 +1,6 @@
 import type {
-  EIAAnimationFrameRefCropped,
-  EIAAnimationMeta,
+  EIAAnimFramePoolItem,
+  EIAAnimationRef,
   EIAFileV1Cropped,
   EIAFileV1CroppedPart,
   EIAManifestV1,
@@ -87,6 +87,44 @@ const applyRects = (
   return result;
 };
 
+const decodePoolFrame = (
+  pool: EIAAnimFramePoolItem[],
+  binarySection: Uint8Array,
+  index: number,
+  depth: number,
+  memo: Map<number, Uint8Array>,
+): Uint8Array => {
+  if (depth > 64) {
+    throw new Error(`Pool reference depth exceeded at index ${index}`);
+  }
+  const cached = memo.get(index);
+  if (cached) return cached;
+
+  const item = pool[index];
+  if (!item) throw new Error(`Pool index ${index} out of bounds`);
+
+  if (item.s < 0 || item.l < 0 || item.s + item.l > binarySection.length) {
+    throw new Error(
+      `Pool frame ${index} data out of bounds: offset ${item.s} + length ${item.l} ` +
+        `exceeds binary section size ${binarySection.length}`,
+    );
+  }
+  const compressed = binarySection.subarray(item.s, item.s + item.l);
+  const decompressed = lz4Decompress(compressed, item.u, `pool_${index}`);
+
+  let result: Uint8Array;
+  if (item.t === "m") {
+    result = decompressed;
+  } else {
+    const base = decodePoolFrame(pool, binarySection, item.b, depth + 1, memo);
+    const copied = new Uint8Array(base);
+    result = applyRects(copied, decompressed, item.r, item.w, item.f);
+  }
+
+  memo.set(index, result);
+  return result;
+};
+
 export const decodeEIAv1 = (buffer: ArrayBuffer): DecodeResult => {
   const uint8 = new Uint8Array(buffer);
   const textDecoder = new TextDecoder();
@@ -114,6 +152,16 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): DecodeResult => {
     manifest.c === "lz4-base64"
       ? textDecoder.decode(uint8.subarray(dataOffset))
       : null;
+
+  // Pre-decode animation pool if present
+  const poolDecoded = new Map<number, Uint8Array>();
+  if (manifest.ac && binarySection) {
+    for (let i = 0; i < manifest.ac.pool.length; i++) {
+      if (!poolDecoded.has(i)) {
+        decodePoolFrame(manifest.ac.pool, binarySection, i, 0, poolDecoded);
+      }
+    }
+  }
 
   const baseNames = new Set(
     manifest.i
@@ -183,110 +231,79 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): DecodeResult => {
     if (!Number.isFinite(index))
       throw new Error(`Non-numeric frame name: "${item.n}"`);
 
-    // Decode animation data from e.a extension (binary lz4 only)
+    // Decode animation data from e.a extension
     let animations: SlideAnimation[] | undefined;
     if (item.e?.a) {
-      if (binarySection === null) {
+      if (!manifest.ac) {
+        console.warn(
+          `Slide "${item.n}" has animation refs but manifest.ac is missing`,
+        );
+      } else if (binarySection === null) {
         console.warn(
           `Animation data for frame "${item.n}" cannot be decoded under lz4-base64 compression`,
         );
       } else {
-        let animMetas: EIAAnimationMeta[] = [];
-        try {
-          const parsed = JSON.parse(item.e.a);
-          if (!Array.isArray(parsed)) {
-            throw new Error("Animation metadata must be an array");
-          }
-          animMetas = parsed as EIAAnimationMeta[];
-        } catch (e) {
-          console.warn(
-            `Failed to parse animation metadata for frame "${item.n}":`,
-            e,
-          );
-        }
-
-        const decodedAnimations = animMetas
-          .map((meta, metaIndex): SlideAnimation | null => {
+        const animRefs = Array.isArray(item.e.a)
+          ? (item.e.a as EIAAnimationRef[])
+          : [];
+        const animationContainer = manifest.ac;
+        const decodedAnimations = animRefs
+          .map((ref, refIndex): SlideAnimation | null => {
             try {
-              const frameWidth = meta.fw ?? meta.w;
-              const frameHeight = meta.fh ?? meta.h;
-              const animFrames: ImageData[] = [];
-              const animFrameBuffers = new Map<number, Uint8Array>();
-
-              // Pre-scan to find which frames are referenced as base by cropped frames
-              const animBaseIndices = new Set<number>();
-              for (const fr of meta.frames) {
-                if ("t" in fr && fr.t === "c") {
-                  animBaseIndices.add((fr as EIAAnimationFrameRefCropped).b);
-                }
+              const anim = animationContainer.anims.find(
+                (a) => a.id === ref.id,
+              );
+              if (!anim) {
+                throw new Error(
+                  `Animation id "${ref.id}" not found in manifest.ac.anims`,
+                );
               }
 
-              for (let fi = 0; fi < meta.frames.length; fi++) {
-                const frameRef = meta.frames[fi];
+              // Validate that all frames in seq share the same dimensions/format
+              const firstPoolItem = animationContainer.pool[anim.seq[0]];
+              if (!firstPoolItem) {
+                throw new Error(`Invalid pool index ${anim.seq[0]} in seq`);
+              }
+              for (let si = 1; si < anim.seq.length; si++) {
+                const poolItem = animationContainer.pool[anim.seq[si]];
+                if (!poolItem) {
+                  throw new Error(`Invalid pool index ${anim.seq[si]} in seq`);
+                }
                 if (
-                  frameRef.s < 0 ||
-                  frameRef.l < 0 ||
-                  frameRef.s + frameRef.l > binarySection.length
+                  poolItem.w !== firstPoolItem.w ||
+                  poolItem.h !== firstPoolItem.h ||
+                  poolItem.f !== firstPoolItem.f
                 ) {
                   throw new Error(
-                    `Animation frame ref out of bounds: offset ${frameRef.s} + length ${frameRef.l} ` +
-                      `exceeds binary section size ${binarySection.length}`,
+                    `Frame dimension/format mismatch in seq at index ${si}`,
                   );
-                }
-                const compressedFrame = binarySection.subarray(
-                  frameRef.s,
-                  frameRef.s + frameRef.l,
-                );
-                const decompressedFrame = lz4Decompress(
-                  compressedFrame,
-                  frameRef.u,
-                  `anim_${item.n}_${metaIndex}_${fi}`,
-                );
-
-                let rawBuffer: Uint8Array;
-                if (!("t" in frameRef) || frameRef.t === "m") {
-                  // Master frame (or legacy frame without 't' field)
-                  rawBuffer = decompressedFrame;
-                } else {
-                  // Cropped frame: apply rects to base
-                  const croppedRef = frameRef as EIAAnimationFrameRefCropped;
-                  const baseBuffer = animFrameBuffers.get(croppedRef.b);
-                  if (!baseBuffer) {
-                    throw new Error(
-                      `Animation base frame ${croppedRef.b} not found for cropped frame ${fi}`,
-                    );
-                  }
-                  rawBuffer = applyRects(
-                    baseBuffer,
-                    decompressedFrame,
-                    croppedRef.r,
-                    frameWidth,
-                    meta.f,
-                  );
-                }
-
-                animFrameBuffers.set(fi, rawBuffer);
-                animFrames.push(
-                  rawToImageData(rawBuffer, frameWidth, frameHeight, meta.f),
-                );
-
-                // Release buffer if not needed as base for future frames
-                if (!animBaseIndices.has(fi)) {
-                  animFrameBuffers.delete(fi);
                 }
               }
+
+              const animFrames: ImageData[] = [];
+              for (const poolIdx of anim.seq) {
+                const frameData = poolDecoded.get(poolIdx);
+                if (!frameData) {
+                  throw new Error(`Pool frame ${poolIdx} not decoded`);
+                }
+                const poolItem = animationContainer.pool[poolIdx];
+                animFrames.push(
+                  rawToImageData(frameData, poolItem.w, poolItem.h, poolItem.f),
+                );
+              }
+
               return {
-                x: meta.x,
-                y: meta.y,
-                w: meta.w,
-                h: meta.h,
-                fps: meta.fps,
+                x: ref.x,
+                y: ref.y,
+                w: ref.w,
+                h: ref.h,
+                fps: anim.fps,
                 frames: animFrames,
               };
             } catch (e) {
               console.warn(
-                `Failed to decode animation meta index ${metaIndex} for frame "${item.n}":`,
-                meta,
+                `Failed to decode animation ref index ${refIndex} for frame "${item.n}":`,
+                ref,
                 e,
               );
               return null;

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -117,8 +117,7 @@ const decodePoolFrame = (
     result = decompressed;
   } else {
     const base = decodePoolFrame(pool, binarySection, item.b, depth + 1, memo);
-    const copied = new Uint8Array(base);
-    result = applyRects(copied, decompressed, item.r, item.w, item.f);
+    result = applyRects(base, decompressed, item.r, item.w, item.f);
   }
 
   memo.set(index, result);

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -94,7 +94,7 @@ const decodePoolFrame = (
   depth: number,
   memo: Map<number, Uint8Array>,
 ): Uint8Array => {
-  if (depth > 64) {
+  if (depth >= 64) {
     throw new Error(`Pool reference depth exceeded at index ${index}`);
   }
   const cached = memo.get(index);

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -114,7 +114,9 @@ const decodePoolFrame = (
 
   let result: Uint8Array;
   if (item.t === "m") {
-    result = decompressed;
+    // Keep memoized master frames isolated from accidental in-place mutation
+    // by future callers.
+    result = new Uint8Array(decompressed);
   } else {
     const base = decodePoolFrame(pool, binarySection, item.b, depth + 1, memo);
     result = applyRects(base, decompressed, item.r, item.w, item.f);

--- a/src/lib/slidePreview/decodeEIAv1.ts
+++ b/src/lib/slidePreview/decodeEIAv1.ts
@@ -94,7 +94,9 @@ const decodePoolFrame = (
   depth: number,
   memo: Map<number, Uint8Array>,
 ): Uint8Array => {
-  if (depth >= 64) {
+  // Depth 65 (next recursive call passes depth === 65) exceeds the documented
+  // 64-level recursion budget; deepest allowed entry is depth 64.
+  if (depth > 64) {
     throw new Error(`Pool reference depth exceeded at index ${index}`);
   }
   const cached = memo.get(index);
@@ -244,9 +246,18 @@ export const decodeEIAv1 = (buffer: ArrayBuffer): DecodeResult => {
           `Animation data for frame "${item.n}" cannot be decoded under lz4-base64 compression`,
         );
       } else {
-        const animRefs = Array.isArray(item.e.a)
-          ? (item.e.a as EIAAnimationRef[])
-          : [];
+        const refsField = item.e.a;
+        let animRefs: EIAAnimationRef[];
+        if (Array.isArray(refsField)) {
+          animRefs = refsField as EIAAnimationRef[];
+        } else if (typeof refsField === "string") {
+          console.warn(
+            `Slide "${item.n}" has legacy JSON-string animation refs in e.a; decode skipped (expected EIAAnimationRef[]).`,
+          );
+          animRefs = [];
+        } else {
+          animRefs = [];
+        }
         const animationContainer = manifest.ac;
         const decodedAnimations = animRefs
           .map((ref, refIndex): SlideAnimation | null => {


### PR DESCRIPTION
## 概要
PR#40 (`spec/eia-animation-container`) で更新されたEIA v1仕様に従い、アニメーション拡張の実装を新方式に移行しました。
旧方式（スライドごとにフレームデータを持つ）から、新方式（マニフェストトップレベルの `ac` にフレームプールとアニメーション定義を集約）へ変更しています。
## 主な変更点
### 型定義 (`src/_types/eia/v1.ts`)
- **追加**: `EIAAnimationContainer`, `EIAAnimFramePoolItem`, `EIAAnimation`, `EIAAnimationRef`
- **削除**: `EIAAnimationMeta`, `EIAAnimationFrameRef` など旧型
- `EIAManifestV1` に `ac?: EIAAnimationContainer` を追加
- `EIAExtensionObject.a` を `string`（JSON文字列）から `EIAAnimationRef[]`（配列そのもの）に変更
### エンコーダー (`src/lib/eia/compressEIAv1.ts`)
- グローバルフレームプールを構築し、`manifest.ac` に集約
- フレームの重複排除（`computeDiffMask` + `countDiffPixels`、閾値0.5%）
- スライドの `e.a` に `EIAAnimationRef[]` をそのまま格納（`JSON.stringify` 廃止）
- 機能フラグを簡略化：`Feature:animation-crop` / `Feature:animation-frame-size` を廃止
### デコーダー (`src/lib/slidePreview/decodeEIAv1.ts`)
- `manifest.ac` からフレームプールをデコード
- `decodePoolFrame` で依存関係を再帰的に解決（メモ化 + 深さ制限64）
- `t: "c"` の場合はベースフレームを**コピー**してからパーツ適用（直接変更禁止）
- `e.a` を配列として直接読み取り（`JSON.parse` 不要）
- フレームサイズと表示サイズの異なる場合の対応
### 同一GIFの重複排除 (`src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts`)
- **クロップ処理前**に元のフレームバッファで同一性を判定
- `cropImages` の結果をキャッシュし、同一GIFは共有
- これにより `compressEIAv1` 内のプール重複排除が正しく機能
### ドキュメント
- `docs/eia-v1-implementation-guide.md`（日本語/英語）の§4を新仕様に更新
## 仕様との対応
| 仕様項目 | 実装状況 |
|---|---|
| `ac` フィールドの追加 | ✅ |
| フレームプール (`pool`) の集約 | ✅ |
| アニメーション定義 (`anims`) の分離 | ✅ |
| `e.a` をJSON配列として格納 | ✅ |
| 同一フレームのプール共有 | ✅ |
| `seq` 内のフレームが同一 `w/h/f` を持つ検証 | ✅ |
| クロップフレームの参照連鎖（深さ制限64） | ✅ |
| ベースフレームのコピー（直接変更禁止） | ✅ |
| Unixエポック基点でのフレームインデックス計算 | ✅（デコーダー側で対応） |
| フレームサイズと表示サイズの異なる場合のスケール | ✅（`drawImage` でレンダラー側が対応） |
## 動作確認
- `npx tsc --noEmit` で型エラーなし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated EIA v1 animation implementation guides with revised encoding/decoding procedures and animation structure specifications.

* **Refactor**
  * Restructured animation representation within EIA v1 manifest from serialized metadata to a pooled architecture with frame deduplication.
  * Rewrote animation decoder to pre-decode pool frames with memoization and enforce recursion depth limits.

* **Performance**
  * Added animation frame caching to reduce redundant processing during slide export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the EIA v1 animation encoding architecture from a per-slide frame-list model to a manifest-level pooled model (`manifest.ac`). Frame data is now deduplicated globally via a two-pass encoder and pre-decoded at parse time in the decoder. The three P1 issues flagged in the prior review (fuzzy cross-animation base deduplication, weak 6-sample frame hash, and hard-coded RGB24 stride in `decodeAnimationFrame`) have all been addressed: exact-match guards (`requireExactMatch`) on base and cropped frames, a full-content dual FNV-1a hash, and a `getBytesPerPixel` helper respectively.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no new P0 or P1 issues found; all three previously reported P1 bugs are correctly resolved.

All previously flagged P1 issues (fuzzy cross-animation base dedup, weak cache hash, hardcoded RGB24 stride) have been addressed with targeted, well-reasoned fixes. The two-pass pool encoder, memoized decoder, and full-content hash are logically consistent and no new defects were found on the changed paths.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/eia/compressEIAv1.ts | Two-pass pool encoder with global frame deduplication, `requireExactMatch` guards for base/cropped frames, `getBytesPerPixel` for format-correct stride — all previously reported P1 issues addressed. |
| src/lib/slidePreview/decodeEIAv1.ts | Pool pre-decode with memoization and depth-65 guard; `applyRects` correctly operates on a copy of the base so memoized buffers are never mutated; legacy JSON-string `e.a` handled gracefully. |
| src/lib/selectedFiles2EIA/selectedFiles2EIAv1RGB24Cropped.ts | Replaces 6-sample weak hash with a full-content dual FNV-1a (64-bit effective) cache key; `cropImages` result is cached per unique GIF so the global pool deduplication in the encoder works correctly. |
| src/_types/eia/v1.ts | New pool-centric types cleanly replace the old per-animation frame-list types; removal of the `& { [key in EIAExtension]?: string }` intersection is safe since `EIAExtensions` only contains "note" and "a". |
| src/lib/google/extractGifAnimations.ts | Trivial filter predicate change from `r !== null` to `!!r` — functionally identical for the `SelectedFileAnimation | null` union. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SF as selectedFiles2EIAv1
    participant CE as compressEIAv1
    participant Pool as Global Frame Pool
    participant DE as decodeEIAv1

    SF->>SF: createAnimationCacheKey (dual FNV-1a full-content hash)
    SF->>SF: cropImages (cached per unique GIF)
    SF->>CE: compressEIAv1(croppedImages, animationMap)

    loop Per animation
        CE->>CE: Pass 1 — decodeAnimationFrame + findMatchingPoolIndex
        Note over CE,Pool: requireExactMatch=true for base frames & cropped frames
        CE->>Pool: Push new decoded buffers to poolDecodedBuffers
        CE->>CE: Pass 2 — compress newPoolFrames, push to pool[]
        CE->>CE: Build seq[] = framePoolIndices
    end

    CE->>CE: manifest.ac = { pool, anims }
    CE->>CE: file.e.a = EIAAnimationRef[] (no JSON.stringify)

    DE->>DE: Parse manifest header
    DE->>Pool: Pre-decode all pool[i] with memoization + depth<=64 guard
    loop Per slide item
        DE->>DE: Read e.a as EIAAnimationRef[]
        DE->>Pool: Look up poolDecoded.get(poolIdx) per seq entry
        DE->>DE: rawToImageData → SlideAnimation.frames[]
    end
```

<sub>Reviews (7): Last reviewed commit: ["fix(eia): warn on legacy animation refs ..."](https://github.com/o-tr/imageslide-converter/commit/a55238f52cb31bb091ce8b6d65ca7a09f968adea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30562249)</sub>

<!-- /greptile_comment -->