### PR TITLE
fix: resolve TypeScript type errors in extractGifAnimations.ts

### DIFF
--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -572,52 +572,62 @@ export const extractGifAnimations = async (
   );
 
   const results = nonIntersectingAnimatedCandidates
-    .map(({ pixelRect, rawFrames, gifWidth, gifHeight }) => {
-      try {
-        const previewFps = derivePreviewFps(rawFrames);
-        const sampleIndices = sampleFrameIndices(rawFrames, previewFps);
-        const { w: targetW, h: targetH } = clampDimensions(gifWidth, gifHeight);
-        const { w: storedFrameW, h: storedFrameH } = clampDimensions(
-          pixelRect.w,
-          pixelRect.h,
-          MAX_STORED_FRAME_DIMENSION,
-        );
-
-        // Build composed GIF frames with proper inter-frame compositing
-        const composedFrames = buildComposedFrames(
-          rawFrames,
-          sampleIndices,
-          gifWidth,
-          gifHeight,
-          targetW,
-          targetH,
-        );
-        const frames = composedFrames.map((frameCanvas) => {
-          const result = compositeWithBackground(
-            baseSlideCanvas,
-            frameCanvas,
-            pixelRect,
-            storedFrameW,
-            storedFrameH,
+    .map(
+      ({
+        pixelRect,
+        rawFrames,
+        gifWidth,
+        gifHeight,
+      }): SelectedFileAnimation | null => {
+        try {
+          const previewFps = derivePreviewFps(rawFrames);
+          const sampleIndices = sampleFrameIndices(rawFrames, previewFps);
+          const { w: targetW, h: targetH } = clampDimensions(
+            gifWidth,
+            gifHeight,
           );
-          // OffscreenCanvas has no close() — rely on GC for resource release.
-          return result;
-        });
+          const { w: storedFrameW, h: storedFrameH } = clampDimensions(
+            pixelRect.w,
+            pixelRect.h,
+            MAX_STORED_FRAME_DIMENSION,
+          );
 
-        return {
-          x: pixelRect.x,
-          y: pixelRect.y,
-          w: pixelRect.w,
-          h: pixelRect.h,
-          fps: previewFps,
-          fpsOverride: Math.min(5, previewFps),
-          frames,
-        } satisfies SelectedFileAnimation;
-      } catch (e) {
-        console.warn("Failed to build composed GIF frames:", e);
-        return null;
-      }
-    })
+          // Build composed GIF frames with proper inter-frame compositing
+          const composedFrames = buildComposedFrames(
+            rawFrames,
+            sampleIndices,
+            gifWidth,
+            gifHeight,
+            targetW,
+            targetH,
+          );
+          const frames = composedFrames.map((frameCanvas) => {
+            const result = compositeWithBackground(
+              baseSlideCanvas,
+              frameCanvas,
+              pixelRect,
+              storedFrameW,
+              storedFrameH,
+            );
+            // OffscreenCanvas has no close() — rely on GC for resource release.
+            return result;
+          });
+
+          return {
+            x: pixelRect.x,
+            y: pixelRect.y,
+            w: pixelRect.w,
+            h: pixelRect.h,
+            fps: previewFps,
+            fpsOverride: Math.min(5, previewFps),
+            frames,
+          } satisfies SelectedFileAnimation;
+        } catch (e) {
+          console.warn("Failed to build composed GIF frames:", e);
+          return null;
+        }
+      },
+    )
     .filter((r): r is SelectedFileAnimation => !!r);
 
   return results;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an explicit `: SelectedFileAnimation | null` return type annotation to the `.map()` callback in `extractGifAnimations.ts`, resolving TypeScript's inability to infer the union return type from the `try/catch` block. The `satisfies SelectedFileAnimation` on the returned object literal is retained for compile-time shape validation. No functional or runtime changes are introduced.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a TypeScript annotation fix with no runtime changes.

The change is limited to adding an explicit return type annotation to a single arrow function. Logic, control flow, and data handling are identical to the base branch. The retained `satisfies SelectedFileAnimation` operator still validates the object shape at compile time, and the downstream `.filter()` type guard is unchanged.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/google/extractGifAnimations.ts | Added explicit `: SelectedFileAnimation | null` return type annotation to the `.map()` callback to resolve TypeScript inference errors. No runtime logic changed. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant extractGifAnimations
    participant mapCallback as .map() callback: SelectedFileAnimation | null
    participant filter as .filter() type guard

    Caller->>extractGifAnimations: call with slide canvas + GIF candidates
    extractGifAnimations->>mapCallback: invoke for each nonIntersectingAnimatedCandidate
    alt success
        mapCallback-->>filter: return SelectedFileAnimation (satisfies check)
    else catch(e)
        mapCallback-->>filter: return null
    end
    filter-->>extractGifAnimations: SelectedFileAnimation[] (nulls removed)
    extractGifAnimations-->>Caller: SelectedFileAnimation[]
```

<sub>Reviews (1): Last reviewed commit: ["fix: resolve TypeScript type errors in e..."](https://github.com/o-tr/imageslide-converter/commit/da719717005c5f44fb91d816bdf972fe2ceecdec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30571663)</sub>

<!-- /greptile_comment -->