### PR TITLE
feat: show red outline for skipped GIF animations disabled by static element overlap

### DIFF
--- a/src/_types/file-picker.ts
+++ b/src/_types/file-picker.ts
@@ -8,6 +8,13 @@ export type SelectedFileAnimation = {
   frames: OffscreenCanvas[];
 };
 
+export type SkippedAnimation = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+};
+
 export type SelectedFile = {
   id: string;
   fileName: string;
@@ -15,6 +22,7 @@ export type SelectedFile = {
   canvas: OffscreenCanvas;
   metadata: SelectedFileMetadata;
   animations?: SelectedFileAnimation[];
+  skippedAnimations?: SkippedAnimation[];
 };
 
 export type SelectedFileMetadataImage = {

--- a/src/_types/file-picker.ts
+++ b/src/_types/file-picker.ts
@@ -1,3 +1,5 @@
+import type { PixelRect } from "@/_types/lib/google/slideGeometry";
+
 export type SelectedFileAnimation = {
   x: number;
   y: number;
@@ -8,7 +10,6 @@ export type SelectedFileAnimation = {
   frames: OffscreenCanvas[];
 };
 
-import type { PixelRect } from "@/_types/lib/google/slideGeometry";
 export type SkippedAnimation = PixelRect;
 
 export type SelectedFile = {

--- a/src/app/(_convert)/convert/pick/_components/FileList/GooglePicker.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/GooglePicker.tsx
@@ -232,7 +232,7 @@ const slide2canvas = async (
   for (const [outputIndex, slide] of filteredSlides.entries()) {
     signal?.throwIfAborted();
     const { canvas, index, speakerNote, pageElements } = slide;
-    const animations = await extractGifAnimations(
+    const { animations, skipped } = await extractGifAnimations(
       pageElements,
       metadata.pageSize,
       { width: canvas.width, height: canvas.height },
@@ -245,6 +245,7 @@ const slide2canvas = async (
       canvas,
       note: speakerNote,
       animations: animations.length > 0 ? animations : undefined,
+      skippedAnimations: skipped.length > 0 ? skipped : undefined,
       metadata: {
         fileType: "pdf" as const,
         file,

--- a/src/app/(_convert)/convert/pick/_components/FileList/MainPreviewArea.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/MainPreviewArea.tsx
@@ -151,6 +151,27 @@ const AnimatedPreview: FC<AnimatedPreviewProps> = ({
             />
           </Dropdown>
         ))}
+        {file.skippedAnimations?.map((anim, i) => (
+          <div
+            key={`skipped-${i}-${anim.x}-${anim.y}-${anim.w}-${anim.h}`}
+            className="absolute group border-2 border-red-500 pointer-events-auto"
+            style={{
+              left: `${(anim.x / file.canvas.width) * 100}%`,
+              top: `${(anim.y / file.canvas.height) * 100}%`,
+              width: `${(anim.w / file.canvas.width) * 100}%`,
+              height: `${(anim.h / file.canvas.height) * 100}%`,
+            }}
+          >
+            <div className="absolute inset-0 bg-red-500/0 group-hover:bg-red-500/20 transition-colors duration-150" />
+            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none">
+              <span className="text-[10px] leading-tight text-red-700 bg-white/90 px-1.5 py-0.5 rounded shadow text-center">
+                アニメーションが無効化されました
+                <br />
+                （静的要素と重なっています）
+              </span>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/app/(_convert)/convert/pick/_components/FileList/MainPreviewArea.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/MainPreviewArea.tsx
@@ -123,57 +123,56 @@ const AnimatedPreview: FC<AnimatedPreviewProps> = ({
   };
 
   return (
-    <div className="w-full h-full flex items-center justify-center">
-      <div
-        className="relative"
-        style={{
-          aspectRatio: `${file.canvas.width} / ${file.canvas.height}`,
-          maxWidth: "100%",
-          maxHeight: "100%",
-        }}
-      >
-        <canvas ref={canvasRef} className="w-full h-full" />
-        {file.animations?.map((anim, i) => (
-          <Dropdown
-            key={`${i}-${anim.x}-${anim.y}-${anim.w}-${anim.h}`}
-            trigger={["contextMenu"]}
-            menu={{ items: buildFpsMenuItems(i, anim) }}
-          >
-            <div
-              className="absolute cursor-context-menu transition-all duration-150 hover:ring-2 hover:ring-inset hover:ring-blue-500/70 hover:bg-blue-500/10"
-              title="右クリックでFPS・解像度を変更"
-              style={{
-                left: `${(anim.x / file.canvas.width) * 100}%`,
-                top: `${(anim.y / file.canvas.height) * 100}%`,
-                width: `${(anim.w / file.canvas.width) * 100}%`,
-                height: `${(anim.h / file.canvas.height) * 100}%`,
-              }}
-            />
-          </Dropdown>
-        ))}
-        {file.skippedAnimations?.map((anim, i) => (
+    <>
+      <canvas ref={canvasRef} className="w-full h-full" />
+      {file.animations?.map((anim, i) => (
+        <Dropdown
+          key={`${i}-${anim.x}-${anim.y}-${anim.w}-${anim.h}`}
+          trigger={["contextMenu"]}
+          menu={{ items: buildFpsMenuItems(i, anim) }}
+        >
           <div
-            key={`skipped-${i}-${anim.x}-${anim.y}-${anim.w}-${anim.h}`}
-            className="absolute group border-2 border-red-500 pointer-events-auto"
+            className="absolute cursor-context-menu transition-all duration-150 hover:ring-2 hover:ring-inset hover:ring-blue-500/70 hover:bg-blue-500/10"
+            title="右クリックでFPS・解像度を変更"
             style={{
               left: `${(anim.x / file.canvas.width) * 100}%`,
               top: `${(anim.y / file.canvas.height) * 100}%`,
               width: `${(anim.w / file.canvas.width) * 100}%`,
               height: `${(anim.h / file.canvas.height) * 100}%`,
             }}
-          >
-            <div className="absolute inset-0 bg-red-500/0 group-hover:bg-red-500/20 transition-colors duration-150" />
-            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none">
-              <span className="text-[10px] leading-tight text-red-700 bg-white/90 px-1.5 py-0.5 rounded shadow text-center">
-                アニメーションが無効化されました
-                <br />
-                （静的要素と重なっています）
-              </span>
-            </div>
+          />
+        </Dropdown>
+      ))}
+    </>
+  );
+};
+
+const SkippedAnimationsOverlay: FC<{ file: SelectedFile }> = ({ file }) => {
+  if (!file.skippedAnimations?.length) return null;
+  return (
+    <>
+      {file.skippedAnimations.map((anim, i) => (
+        <div
+          key={`skipped-${i}-${anim.x}-${anim.y}-${anim.w}-${anim.h}`}
+          className="absolute group border-2 border-red-500 pointer-events-auto"
+          style={{
+            left: `${(anim.x / file.canvas.width) * 100}%`,
+            top: `${(anim.y / file.canvas.height) * 100}%`,
+            width: `${(anim.w / file.canvas.width) * 100}%`,
+            height: `${(anim.h / file.canvas.height) * 100}%`,
+          }}
+        >
+          <div className="absolute inset-0 bg-red-500/0 group-hover:bg-red-500/20 transition-colors duration-150" />
+          <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none">
+            <span className="text-[10px] leading-tight text-red-700 bg-white/90 px-1.5 py-0.5 rounded shadow text-center">
+              アニメーションが無効化されました
+              <br />
+              （静的要素と重なっています）
+            </span>
           </div>
-        ))}
-      </div>
-    </div>
+        </div>
+      ))}
+    </>
   );
 };
 
@@ -202,15 +201,27 @@ export const MainPreviewArea: FC<MainPreviewAreaProps> = ({
         <div
           className={"w-full aspect-video bg-gray-100 rounded overflow-hidden"}
         >
-          {file.animations?.length ? (
-            <AnimatedPreview
-              key={file.id}
-              file={file}
-              onAnimationFpsChange={handleFpsChange}
-            />
-          ) : (
-            <Preview canvas={file.canvas} className={"w-full h-full"} />
-          )}
+          <div className="w-full h-full flex items-center justify-center">
+            <div
+              className="relative"
+              style={{
+                aspectRatio: `${file.canvas.width} / ${file.canvas.height}`,
+                maxWidth: "100%",
+                maxHeight: "100%",
+              }}
+            >
+              {file.animations?.length ? (
+                <AnimatedPreview
+                  key={file.id}
+                  file={file}
+                  onAnimationFpsChange={handleFpsChange}
+                />
+              ) : (
+                <Preview canvas={file.canvas} className={"w-full h-full"} />
+              )}
+              <SkippedAnimationsOverlay file={file} />
+            </div>
+          </div>
         </div>
       </div>
       <Flex vertical gap={4} className={""}>

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -310,13 +310,18 @@ const compositeWithBackground = (
   return composited;
 };
 
+export type ExtractGifAnimationsResult = {
+  animations: SelectedFileAnimation[];
+  skipped: PixelRect[];
+};
+
 export const extractGifAnimations = async (
   pageElements: SlidePageElement[],
   pageSize: PageSize,
   canvasSize: CanvasSize,
   baseSlideCanvas: OffscreenCanvas,
   signal?: AbortSignal,
-): Promise<SelectedFileAnimation[]> => {
+): Promise<ExtractGifAnimationsResult> => {
   const imageElements = pageElements
     .map((element) => {
       const contentUrl = element.image?.contentUrl;
@@ -565,6 +570,11 @@ export const extractGifAnimations = async (
     );
   }
 
+  const skippedRects: PixelRect[] = [];
+  for (const index of intersectingNonAnimatedIndices) {
+    skippedRects.push(animatedGifCandidates[index].pixelRect);
+  }
+
   const nonIntersectingAnimatedCandidates = animatedGifCandidates.filter(
     (_, index) =>
       !intersectingElementIndices.has(index) &&
@@ -572,53 +582,58 @@ export const extractGifAnimations = async (
   );
 
   const results = nonIntersectingAnimatedCandidates
-    .map(({ pixelRect, rawFrames, gifWidth, gifHeight }) => {
-      try {
-        const previewFps = derivePreviewFps(rawFrames);
-        const sampleIndices = sampleFrameIndices(rawFrames, previewFps);
-        const { w: targetW, h: targetH } = clampDimensions(gifWidth, gifHeight);
-        const { w: storedFrameW, h: storedFrameH } = clampDimensions(
-          pixelRect.w,
-          pixelRect.h,
-          MAX_STORED_FRAME_DIMENSION,
-        );
-
-        // Build composed GIF frames with proper inter-frame compositing
-        const composedFrames = buildComposedFrames(
-          rawFrames,
-          sampleIndices,
-          gifWidth,
-          gifHeight,
-          targetW,
-          targetH,
-        );
-        const frames = composedFrames.map((frameCanvas) => {
-          const result = compositeWithBackground(
-            baseSlideCanvas,
-            frameCanvas,
-            pixelRect,
-            storedFrameW,
-            storedFrameH,
+    .map<SelectedFileAnimation | null>(
+      ({ pixelRect, rawFrames, gifWidth, gifHeight }) => {
+        try {
+          const previewFps = derivePreviewFps(rawFrames);
+          const sampleIndices = sampleFrameIndices(rawFrames, previewFps);
+          const { w: targetW, h: targetH } = clampDimensions(
+            gifWidth,
+            gifHeight,
           );
-          // OffscreenCanvas has no close() — rely on GC for resource release.
-          return result;
-        });
+          const { w: storedFrameW, h: storedFrameH } = clampDimensions(
+            pixelRect.w,
+            pixelRect.h,
+            MAX_STORED_FRAME_DIMENSION,
+          );
 
-        return {
-          x: pixelRect.x,
-          y: pixelRect.y,
-          w: pixelRect.w,
-          h: pixelRect.h,
-          fps: previewFps,
-          fpsOverride: Math.min(5, previewFps),
-          frames,
-        } satisfies SelectedFileAnimation;
-      } catch (e) {
-        console.warn("Failed to build composed GIF frames:", e);
-        return null;
-      }
-    })
+          // Build composed GIF frames with proper inter-frame compositing
+          const composedFrames = buildComposedFrames(
+            rawFrames,
+            sampleIndices,
+            gifWidth,
+            gifHeight,
+            targetW,
+            targetH,
+          );
+          const frames = composedFrames.map((frameCanvas) => {
+            const result = compositeWithBackground(
+              baseSlideCanvas,
+              frameCanvas,
+              pixelRect,
+              storedFrameW,
+              storedFrameH,
+            );
+            // OffscreenCanvas has no close() — rely on GC for resource release.
+            return result;
+          });
+
+          return {
+            x: pixelRect.x,
+            y: pixelRect.y,
+            w: pixelRect.w,
+            h: pixelRect.h,
+            fps: previewFps,
+            fpsOverride: Math.min(5, previewFps),
+            frames,
+          };
+        } catch (e) {
+          console.warn("Failed to build composed GIF frames:", e);
+          return null;
+        }
+      },
+    )
     .filter((r): r is SelectedFileAnimation => !!r);
 
-  return results;
+  return { animations: results, skipped: skippedRects };
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces previously-silently-skipped GIF animations (those disabled because a static element overlaps them) to the user via red-outlined overlays in the slide preview, with a hover tooltip explaining the reason. The implementation collects skipped rects in `extractGifAnimations`, threads them through `SelectedFile`, and renders them via a new `SkippedAnimationsOverlay` component; layout ownership for the aspect-ratio container was also lifted from `AnimatedPreview` into `MainPreviewArea` so both animated and static previews share the same overlay layer.

<h3>Confidence Score: 5/5</h3>

Safe to merge — logic is correct, no P1/P0 issues found.

The two index sets (`intersectingElementIndices` and `intersectingNonAnimatedIndices`) are guaranteed mutually exclusive by the `if (intersectingElementIndices.has(i)) continue` guard, so no duplicate rects can appear. The layout refactor correctly preserves the relative positioning context needed by all absolute overlays. No data loss, no security concerns, no runtime breakage found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/google/extractGifAnimations.ts | Return type extended to `ExtractGifAnimationsResult`; skipped rects collected from both `intersectingElementIndices` and `intersectingNonAnimatedIndices` (mutually exclusive sets, so no duplicates) and returned alongside animations. |
| src/_types/file-picker.ts | Adds `SkippedAnimation` type alias (now correctly aliasing `PixelRect`) and optional `skippedAnimations` field to `SelectedFile`. |
| src/app/(_convert)/convert/pick/_components/FileList/GooglePicker.tsx | Destructures the new `{ animations, skipped }` return value from `extractGifAnimations` and maps `skipped` to `skippedAnimations` on the slide object. |
| src/app/(_convert)/convert/pick/_components/FileList/MainPreviewArea.tsx | Restructured layout so the aspect-ratio container lives in `MainPreviewArea`; added `SkippedAnimationsOverlay` component that renders absolute red-bordered divs with hover tooltips for each skipped GIF. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GP as GooglePicker
    participant EGA as extractGifAnimations
    participant MPA as MainPreviewArea
    participant SAO as SkippedAnimationsOverlay

    GP->>EGA: extractGifAnimations(pageElements, ...)
    EGA->>EGA: detect intersectingElementIndices
    EGA->>EGA: detect intersectingNonAnimatedIndices
    EGA->>EGA: collect skippedRects from both sets
    EGA-->>GP: { animations, skipped }
    GP->>GP: map skipped → skippedAnimations on SelectedFile

    GP->>MPA: render file (with skippedAnimations)
    MPA->>MPA: render aspect-ratio container
    alt file.animations?.length
        MPA->>MPA: render AnimatedPreview (canvas + blue overlays)
    else
        MPA->>MPA: render static Preview canvas
    end
    MPA->>SAO: render SkippedAnimationsOverlay(file)
    SAO->>SAO: render absolute red-bordered div per skippedAnimation
    SAO-->>MPA: hover tooltip アニメーションが無効化されました
```

<sub>Reviews (3): Last reviewed commit: ["style: move import to top of module in f..."](https://github.com/o-tr/imageslide-converter/commit/1261a40d42bf96e192dfeee981d8bb31c29a77c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30572040)</sub>

<!-- /greptile_comment -->