### PR TITLE
feat: show GIF and skipped animation icons in pick slide list

### DIFF
--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -4,6 +4,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Dropdown } from "antd";
 import type { MenuProps } from "antd";
+import { ImagePlay, TriangleAlert } from "lucide-react";
 import type { CSSProperties, FC } from "react";
 import { MdDeleteOutline } from "react-icons/md";
 import { Preview } from "./Preview";
@@ -65,7 +66,16 @@ const SlideItem: FC<SlideItemProps> = ({
         className="col-span-full grid grid-cols-subgrid cursor-pointer shrink-0"
         onClick={() => onSelect(index)}
       >
-        <span className={"text-xs text-gray-500 text-right"}>{index + 1}</span>
+        <div className="flex flex-col items-end gap-0.5">
+          <span className="text-xs text-gray-500 text-right">{index + 1}</span>
+          {((file.animations && file.animations.length > 0) ||
+            (file.skippedAnimations && file.skippedAnimations.length > 0)) && (
+            <ImagePlay className="text-xs text-blue-500 w-3 h-3" />
+          )}
+          {file.skippedAnimations && file.skippedAnimations.length > 0 && (
+            <TriangleAlert className="text-xs text-yellow-500 w-3 h-3" />
+          )}
+        </div>
         <Preview
           canvas={file.canvas}
           className={`w-full border-2 rounded overflow-hidden ${

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -68,16 +68,19 @@ const SlideItem: FC<SlideItemProps> = ({
       >
         <div className="flex flex-col items-end gap-0.5">
           <span className="text-xs text-gray-500 text-right">{index + 1}</span>
-          {(file.animations?.length || file.skippedAnimations?.length) && (
+          {((file.animations?.length ?? 0) > 0 ||
+            (file.skippedAnimations?.length ?? 0) > 0) && (
             <ImagePlay
               className="text-blue-500 w-3 h-3"
               aria-label="GIFアニメーションを含む"
+              role="img"
             />
           )}
-          {file.skippedAnimations?.length && (
+          {(file.skippedAnimations?.length ?? 0) > 0 && (
             <TriangleAlert
               className="text-yellow-500 w-3 h-3"
               aria-label="一部のアニメーションがスキップされました"
+              role="img"
             />
           )}
         </div>

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -45,12 +45,6 @@ const SlideItem: FC<SlideItemProps> = memo(
     const hasAnimations = (file.animations?.length ?? 0) > 0;
     const hasSkippedAnimations = (file.skippedAnimations?.length ?? 0) > 0;
 
-    const parts: string[] = [];
-    if (hasAnimations) parts.push("GIFアニメーションを含む");
-    if (hasSkippedAnimations)
-      parts.push("警告：一部のアニメーションがスキップされています");
-    const statusLabel = parts.join("、");
-
     const menuItems: MenuProps["items"] = [
       {
         key: "delete",
@@ -78,14 +72,15 @@ const SlideItem: FC<SlideItemProps> = memo(
             {(hasAnimations || hasSkippedAnimations) && (
               <ImagePlay
                 className="text-blue-500 w-3 h-3"
-                aria-label={statusLabel}
+                aria-label="GIFアニメーションを含む"
                 role="img"
               />
             )}
             {hasSkippedAnimations && (
               <TriangleAlert
                 className="text-yellow-500 w-3 h-3"
-                aria-hidden="true"
+                aria-label="一部のアニメーションがスキップされました"
+                role="img"
               />
             )}
           </div>

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -5,7 +5,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { Dropdown } from "antd";
 import type { MenuProps } from "antd";
 import { ImagePlay, TriangleAlert } from "lucide-react";
-import { memo, useMemo } from "react";
+import { memo } from "react";
 import type { CSSProperties, FC } from "react";
 import { MdDeleteOutline } from "react-icons/md";
 import { Preview } from "./Preview";
@@ -36,30 +36,24 @@ const SlideItem: FC<SlideItemProps> = memo(
       isDragging,
     } = useSortable({ id: file.id });
 
-    const style: CSSProperties = useMemo(
-      () => ({
-        transform: CSS.Transform.toString(transform),
-        transition,
-        ...(isDragging ? { opacity: 0.5, zIndex: 9999 } : {}),
-      }),
-      [transform, transition, isDragging],
-    );
+    const style: CSSProperties = {
+      transform: CSS.Transform.toString(transform),
+      transition,
+      ...(isDragging ? { opacity: 0.5, zIndex: 9999 } : {}),
+    };
 
     const hasAnimations = (file.animations?.length ?? 0) > 0;
     const hasSkippedAnimations = (file.skippedAnimations?.length ?? 0) > 0;
 
-    const menuItems: MenuProps["items"] = useMemo(
-      () => [
-        {
-          key: "delete",
-          label: "削除",
-          danger: true,
-          icon: <MdDeleteOutline />,
-          onClick: () => onDelete(file.id),
-        },
-      ],
-      [file.id, onDelete],
-    );
+    const menuItems: MenuProps["items"] = [
+      {
+        key: "delete",
+        label: "削除",
+        danger: true,
+        icon: <MdDeleteOutline />,
+        onClick: () => onDelete(file.id),
+      },
+    ];
 
     return (
       <Dropdown menu={{ items: menuItems }} trigger={["contextMenu"]}>
@@ -83,7 +77,7 @@ const SlideItem: FC<SlideItemProps> = memo(
                     ? "GIFアニメーションを含む（一部スキップ）"
                     : hasAnimations
                       ? "GIFアニメーションを含む"
-                      : "元のGIFにアニメーションが含まれていた"
+                      : "元のGIFにアニメーションが含まれていたが、スキップされました"
                 }
                 role="img"
               />

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -5,7 +5,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { Dropdown } from "antd";
 import type { MenuProps } from "antd";
 import { ImagePlay, TriangleAlert } from "lucide-react";
-import { memo } from "react";
+import { memo, useMemo } from "react";
 import type { CSSProperties, FC } from "react";
 import { MdDeleteOutline } from "react-icons/md";
 import { Preview } from "./Preview";
@@ -45,15 +45,22 @@ const SlideItem: FC<SlideItemProps> = memo(
     const hasAnimations = (file.animations?.length ?? 0) > 0;
     const hasSkippedAnimations = (file.skippedAnimations?.length ?? 0) > 0;
 
-    const menuItems: MenuProps["items"] = [
-      {
-        key: "delete",
-        label: "削除",
-        danger: true,
-        icon: <MdDeleteOutline />,
-        onClick: () => onDelete(file.id),
-      },
-    ];
+    const imagePlayLabel = hasAnimations
+      ? "GIFアニメーションを含む"
+      : "元のGIFにアニメーションが含まれていたが、スキップされました";
+
+    const menuItems: MenuProps["items"] = useMemo(
+      () => [
+        {
+          key: "delete",
+          label: "削除",
+          danger: true,
+          icon: <MdDeleteOutline />,
+          onClick: () => onDelete(file.id),
+        },
+      ],
+      [file.id, onDelete],
+    );
 
     return (
       <Dropdown menu={{ items: menuItems }} trigger={["contextMenu"]}>
@@ -72,13 +79,7 @@ const SlideItem: FC<SlideItemProps> = memo(
             {(hasAnimations || hasSkippedAnimations) && (
               <ImagePlay
                 className="text-blue-500 w-3 h-3"
-                aria-label={
-                  hasAnimations && hasSkippedAnimations
-                    ? "GIFアニメーションを含む（一部スキップ）"
-                    : hasAnimations
-                      ? "GIFアニメーションを含む"
-                      : "元のGIFにアニメーションが含まれていたが、スキップされました"
-                }
+                aria-label={imagePlayLabel}
                 role="img"
               />
             )}

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -70,6 +70,7 @@ const SlideItem: FC<SlideItemProps> = memo(
           {...listeners}
           className="col-span-full grid grid-cols-subgrid cursor-pointer shrink-0"
           onClick={() => onSelect(index)}
+          aria-current={isSelected ? "true" : undefined}
         >
           <div className="flex flex-col items-end gap-0.5">
             <span className="sr-only">
@@ -100,6 +101,7 @@ const SlideItem: FC<SlideItemProps> = memo(
                 ? "border-blue-500"
                 : "border-transparent hover:border-gray-300"
             }`}
+            aria-hidden="true"
           />
         </div>
       </Dropdown>

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -45,12 +45,11 @@ const SlideItem: FC<SlideItemProps> = memo(
     const hasAnimations = (file.animations?.length ?? 0) > 0;
     const hasSkippedAnimations = (file.skippedAnimations?.length ?? 0) > 0;
 
-    const imagePlayLabel = [
-      hasAnimations && "GIFアニメーションを含む",
-      hasSkippedAnimations && "一部のアニメーションがスキップされています",
-    ]
-      .filter(Boolean)
-      .join("、");
+    const parts: string[] = [];
+    if (hasAnimations) parts.push("GIFアニメーションを含む");
+    if (hasSkippedAnimations)
+      parts.push("一部のアニメーションがスキップされています");
+    const imagePlayLabel = parts.join("、");
 
     const menuItems: MenuProps["items"] = [
       {
@@ -79,7 +78,7 @@ const SlideItem: FC<SlideItemProps> = memo(
             {(hasAnimations || hasSkippedAnimations) && (
               <ImagePlay
                 className="text-blue-500 w-3 h-3"
-                aria-label={imagePlayLabel || undefined}
+                aria-label={imagePlayLabel}
                 role="img"
               />
             )}

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -45,6 +45,12 @@ const SlideItem: FC<SlideItemProps> = memo(
     const hasAnimations = (file.animations?.length ?? 0) > 0;
     const hasSkippedAnimations = (file.skippedAnimations?.length ?? 0) > 0;
 
+    const slideStatusParts: string[] = [];
+    if (hasAnimations) slideStatusParts.push("GIFアニメーションを含む");
+    if (hasSkippedAnimations)
+      slideStatusParts.push("一部のアニメーションがスキップされました");
+    const slideStatus = slideStatusParts.join("、");
+
     const menuItems: MenuProps["items"] = [
       {
         key: "delete",
@@ -65,22 +71,20 @@ const SlideItem: FC<SlideItemProps> = memo(
           className="col-span-full grid grid-cols-subgrid cursor-pointer shrink-0"
           onClick={() => onSelect(index)}
         >
-          <div className="flex flex-col items-end gap-0.5">
+          <div
+            className="flex flex-col items-end gap-0.5"
+            aria-label={slideStatus || undefined}
+          >
             <span className="text-xs text-gray-500 text-right">
               {index + 1}
             </span>
             {(hasAnimations || hasSkippedAnimations) && (
-              <ImagePlay
-                className="text-blue-500 w-3 h-3"
-                aria-label="GIFアニメーションを含む"
-                role="img"
-              />
+              <ImagePlay className="text-blue-500 w-3 h-3" aria-hidden="true" />
             )}
             {hasSkippedAnimations && (
               <TriangleAlert
                 className="text-yellow-500 w-3 h-3"
-                aria-label="一部のアニメーションがスキップされました"
-                role="img"
+                aria-hidden="true"
               />
             )}
           </div>

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -70,7 +70,6 @@ const SlideItem: FC<SlideItemProps> = memo(
           {...listeners}
           className="col-span-full grid grid-cols-subgrid cursor-pointer shrink-0"
           onClick={() => onSelect(index)}
-          aria-current={isSelected ? "true" : undefined}
         >
           <div className="flex flex-col items-end gap-0.5">
             <span className="sr-only">
@@ -101,7 +100,6 @@ const SlideItem: FC<SlideItemProps> = memo(
                 ? "border-blue-500"
                 : "border-transparent hover:border-gray-300"
             }`}
-            aria-hidden="true"
           />
         </div>
       </Dropdown>

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -49,7 +49,7 @@ const SlideItem: FC<SlideItemProps> = memo(
     if (hasAnimations) slideStatusParts.push("GIFアニメーションを含む");
     if (hasSkippedAnimations)
       slideStatusParts.push("一部のアニメーションがスキップされました");
-    const slideStatus = slideStatusParts.join("、");
+    const slideStatus = `${slideStatusParts.join("、")}。`;
 
     const menuItems: MenuProps["items"] = [
       {
@@ -75,6 +75,7 @@ const SlideItem: FC<SlideItemProps> = memo(
             <span className="sr-only">
               {index + 1}番目のスライド
               {slideStatus ? `、${slideStatus}` : ""}
+              {isSelected ? "、選択中" : ""}
             </span>
             <span
               className="text-xs text-gray-500 text-right"

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -45,6 +45,13 @@ const SlideItem: FC<SlideItemProps> = memo(
     const hasAnimations = (file.animations?.length ?? 0) > 0;
     const hasSkippedAnimations = (file.skippedAnimations?.length ?? 0) > 0;
 
+    const imagePlayLabel = [
+      hasAnimations && "GIFアニメーションを含む",
+      hasSkippedAnimations && "一部のアニメーションがスキップされています",
+    ]
+      .filter(Boolean)
+      .join("、");
+
     const menuItems: MenuProps["items"] = [
       {
         key: "delete",
@@ -72,19 +79,14 @@ const SlideItem: FC<SlideItemProps> = memo(
             {(hasAnimations || hasSkippedAnimations) && (
               <ImagePlay
                 className="text-blue-500 w-3 h-3"
-                aria-label={
-                  hasAnimations
-                    ? "GIFアニメーションを含む"
-                    : "スキップされたアニメーション情報あり"
-                }
+                aria-label={imagePlayLabel || undefined}
                 role="img"
               />
             )}
             {hasSkippedAnimations && (
               <TriangleAlert
                 className="text-yellow-500 w-3 h-3"
-                aria-label="一部のアニメーションがスキップされました"
-                role="img"
+                aria-hidden="true"
               />
             )}
           </div>

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -72,7 +72,11 @@ const SlideItem: FC<SlideItemProps> = memo(
             {(hasAnimations || hasSkipped) && (
               <ImagePlay
                 className="text-blue-500 w-3 h-3"
-                aria-label="GIFアニメーション情報あり"
+                aria-label={
+                  hasAnimations
+                    ? "GIFアニメーションを含む"
+                    : "元のGIFにアニメーションが含まれていた"
+                }
                 role="img"
               />
             )}

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -72,8 +72,14 @@ const SlideItem: FC<SlideItemProps> = memo(
           onClick={() => onSelect(index)}
         >
           <div className="flex flex-col items-end gap-0.5">
-            {slideStatus && <span className="sr-only">{slideStatus}</span>}
-            <span className="text-xs text-gray-500 text-right">
+            <span className="sr-only">
+              {index + 1}番目のスライド
+              {slideStatus ? `、${slideStatus}` : ""}
+            </span>
+            <span
+              className="text-xs text-gray-500 text-right"
+              aria-hidden="true"
+            >
               {index + 1}
             </span>
             {(hasAnimations || hasSkippedAnimations) && (

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -5,7 +5,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { Dropdown } from "antd";
 import type { MenuProps } from "antd";
 import { ImagePlay, TriangleAlert } from "lucide-react";
-import { memo, useMemo } from "react";
+import { memo } from "react";
 import type { CSSProperties, FC } from "react";
 import { MdDeleteOutline } from "react-icons/md";
 import { Preview } from "./Preview";
@@ -45,20 +45,15 @@ const SlideItem: FC<SlideItemProps> = memo(
     const hasAnimations = (file.animations?.length ?? 0) > 0;
     const hasSkippedAnimations = (file.skippedAnimations?.length ?? 0) > 0;
 
-    const imagePlayLabel = "GIFアニメーションを含む";
-
-    const menuItems: MenuProps["items"] = useMemo(
-      () => [
-        {
-          key: "delete",
-          label: "削除",
-          danger: true,
-          icon: <MdDeleteOutline />,
-          onClick: () => onDelete(file.id),
-        },
-      ],
-      [file.id, onDelete],
-    );
+    const menuItems: MenuProps["items"] = [
+      {
+        key: "delete",
+        label: "削除",
+        danger: true,
+        icon: <MdDeleteOutline />,
+        onClick: () => onDelete(file.id),
+      },
+    ];
 
     return (
       <Dropdown menu={{ items: menuItems }} trigger={["contextMenu"]}>
@@ -77,7 +72,11 @@ const SlideItem: FC<SlideItemProps> = memo(
             {(hasAnimations || hasSkippedAnimations) && (
               <ImagePlay
                 className="text-blue-500 w-3 h-3"
-                aria-label={imagePlayLabel}
+                aria-label={
+                  hasAnimations
+                    ? "GIFアニメーションを含む"
+                    : "スキップされたアニメーション情報あり"
+                }
                 role="img"
               />
             )}

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -5,7 +5,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { Dropdown } from "antd";
 import type { MenuProps } from "antd";
 import { ImagePlay, TriangleAlert } from "lucide-react";
-import { memo } from "react";
+import { memo, useMemo } from "react";
 import type { CSSProperties, FC } from "react";
 import { MdDeleteOutline } from "react-icons/md";
 import { Preview } from "./Preview";
@@ -36,24 +36,30 @@ const SlideItem: FC<SlideItemProps> = memo(
       isDragging,
     } = useSortable({ id: file.id });
 
-    const style: CSSProperties = {
-      transform: CSS.Transform.toString(transform),
-      transition,
-      ...(isDragging ? { opacity: 0.5, zIndex: 9999 } : {}),
-    };
+    const style: CSSProperties = useMemo(
+      () => ({
+        transform: CSS.Transform.toString(transform),
+        transition,
+        ...(isDragging ? { opacity: 0.5, zIndex: 9999 } : {}),
+      }),
+      [transform, transition, isDragging],
+    );
 
     const hasAnimations = (file.animations?.length ?? 0) > 0;
-    const hasSkipped = (file.skippedAnimations?.length ?? 0) > 0;
+    const hasSkippedAnimations = (file.skippedAnimations?.length ?? 0) > 0;
 
-    const menuItems: MenuProps["items"] = [
-      {
-        key: "delete",
-        label: "削除",
-        danger: true,
-        icon: <MdDeleteOutline />,
-        onClick: () => onDelete(file.id),
-      },
-    ];
+    const menuItems: MenuProps["items"] = useMemo(
+      () => [
+        {
+          key: "delete",
+          label: "削除",
+          danger: true,
+          icon: <MdDeleteOutline />,
+          onClick: () => onDelete(file.id),
+        },
+      ],
+      [file.id, onDelete],
+    );
 
     return (
       <Dropdown menu={{ items: menuItems }} trigger={["contextMenu"]}>
@@ -69,18 +75,20 @@ const SlideItem: FC<SlideItemProps> = memo(
             <span className="text-xs text-gray-500 text-right">
               {index + 1}
             </span>
-            {(hasAnimations || hasSkipped) && (
+            {(hasAnimations || hasSkippedAnimations) && (
               <ImagePlay
                 className="text-blue-500 w-3 h-3"
                 aria-label={
-                  hasAnimations
-                    ? "GIFアニメーションを含む"
-                    : "元のGIFにアニメーションが含まれていた"
+                  hasAnimations && hasSkippedAnimations
+                    ? "GIFアニメーションを含む（一部スキップ）"
+                    : hasAnimations
+                      ? "GIFアニメーションを含む"
+                      : "元のGIFにアニメーションが含まれていた"
                 }
                 role="img"
               />
             )}
-            {hasSkipped && (
+            {hasSkippedAnimations && (
               <TriangleAlert
                 className="text-yellow-500 w-3 h-3"
                 aria-label="一部のアニメーションがスキップされました"

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -48,8 +48,8 @@ const SlideItem: FC<SlideItemProps> = memo(
     const parts: string[] = [];
     if (hasAnimations) parts.push("GIFアニメーションを含む");
     if (hasSkippedAnimations)
-      parts.push("一部のアニメーションがスキップされています");
-    const imagePlayLabel = parts.join("、");
+      parts.push("警告：一部のアニメーションがスキップされています");
+    const statusLabel = parts.join("、");
 
     const menuItems: MenuProps["items"] = [
       {
@@ -78,7 +78,7 @@ const SlideItem: FC<SlideItemProps> = memo(
             {(hasAnimations || hasSkippedAnimations) && (
               <ImagePlay
                 className="text-blue-500 w-3 h-3"
-                aria-label={imagePlayLabel}
+                aria-label={statusLabel}
                 role="img"
               />
             )}

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -71,10 +71,8 @@ const SlideItem: FC<SlideItemProps> = memo(
           className="col-span-full grid grid-cols-subgrid cursor-pointer shrink-0"
           onClick={() => onSelect(index)}
         >
-          <div
-            className="flex flex-col items-end gap-0.5"
-            aria-label={slideStatus || undefined}
-          >
+          <div className="flex flex-col items-end gap-0.5">
+            {slideStatus && <span className="sr-only">{slideStatus}</span>}
             <span className="text-xs text-gray-500 text-right">
               {index + 1}
             </span>

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -49,7 +49,7 @@ const SlideItem: FC<SlideItemProps> = memo(
     if (hasAnimations) slideStatusParts.push("GIFアニメーションを含む");
     if (hasSkippedAnimations)
       slideStatusParts.push("一部のアニメーションがスキップされました");
-    const slideStatus = `${slideStatusParts.join("、")}。`;
+    const slideStatus = slideStatusParts.join("、");
 
     const menuItems: MenuProps["items"] = [
       {

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -68,12 +68,17 @@ const SlideItem: FC<SlideItemProps> = ({
       >
         <div className="flex flex-col items-end gap-0.5">
           <span className="text-xs text-gray-500 text-right">{index + 1}</span>
-          {((file.animations && file.animations.length > 0) ||
-            (file.skippedAnimations && file.skippedAnimations.length > 0)) && (
-            <ImagePlay className="text-xs text-blue-500 w-3 h-3" />
+          {(file.animations?.length || file.skippedAnimations?.length) && (
+            <ImagePlay
+              className="text-blue-500 w-3 h-3"
+              aria-label="GIFアニメーションを含む"
+            />
           )}
-          {file.skippedAnimations && file.skippedAnimations.length > 0 && (
-            <TriangleAlert className="text-xs text-yellow-500 w-3 h-3" />
+          {file.skippedAnimations?.length && (
+            <TriangleAlert
+              className="text-yellow-500 w-3 h-3"
+              aria-label="一部のアニメーションがスキップされました"
+            />
           )}
         </div>
         <Preview

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -5,6 +5,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { Dropdown } from "antd";
 import type { MenuProps } from "antd";
 import { ImagePlay, TriangleAlert } from "lucide-react";
+import { memo } from "react";
 import type { CSSProperties, FC } from "react";
 import { MdDeleteOutline } from "react-icons/md";
 import { Preview } from "./Preview";
@@ -24,78 +25,80 @@ interface SlideItemProps {
   onDelete: (id: string) => void;
 }
 
-const SlideItem: FC<SlideItemProps> = ({
-  file,
-  index,
-  isSelected,
-  onSelect,
-  onDelete,
-}) => {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id: file.id });
+const SlideItem: FC<SlideItemProps> = memo(
+  ({ file, index, isSelected, onSelect, onDelete }) => {
+    const {
+      attributes,
+      listeners,
+      setNodeRef,
+      transform,
+      transition,
+      isDragging,
+    } = useSortable({ id: file.id });
 
-  const style: CSSProperties = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    ...(isDragging ? { opacity: 0.5, zIndex: 9999 } : {}),
-  };
+    const style: CSSProperties = {
+      transform: CSS.Transform.toString(transform),
+      transition,
+      ...(isDragging ? { opacity: 0.5, zIndex: 9999 } : {}),
+    };
 
-  const menuItems: MenuProps["items"] = [
-    {
-      key: "delete",
-      label: "削除",
-      danger: true,
-      icon: <MdDeleteOutline />,
-      onClick: () => onDelete(file.id),
-    },
-  ];
+    const hasAnimations = (file.animations?.length ?? 0) > 0;
+    const hasSkipped = (file.skippedAnimations?.length ?? 0) > 0;
 
-  return (
-    <Dropdown menu={{ items: menuItems }} trigger={["contextMenu"]}>
-      <div
-        ref={setNodeRef}
-        style={style}
-        {...attributes}
-        {...listeners}
-        className="col-span-full grid grid-cols-subgrid cursor-pointer shrink-0"
-        onClick={() => onSelect(index)}
-      >
-        <div className="flex flex-col items-end gap-0.5">
-          <span className="text-xs text-gray-500 text-right">{index + 1}</span>
-          {((file.animations?.length ?? 0) > 0 ||
-            (file.skippedAnimations?.length ?? 0) > 0) && (
-            <ImagePlay
-              className="text-blue-500 w-3 h-3"
-              aria-label="GIFアニメーションを含む"
-              role="img"
-            />
-          )}
-          {(file.skippedAnimations?.length ?? 0) > 0 && (
-            <TriangleAlert
-              className="text-yellow-500 w-3 h-3"
-              aria-label="一部のアニメーションがスキップされました"
-              role="img"
-            />
-          )}
+    const menuItems: MenuProps["items"] = [
+      {
+        key: "delete",
+        label: "削除",
+        danger: true,
+        icon: <MdDeleteOutline />,
+        onClick: () => onDelete(file.id),
+      },
+    ];
+
+    return (
+      <Dropdown menu={{ items: menuItems }} trigger={["contextMenu"]}>
+        <div
+          ref={setNodeRef}
+          style={style}
+          {...attributes}
+          {...listeners}
+          className="col-span-full grid grid-cols-subgrid cursor-pointer shrink-0"
+          onClick={() => onSelect(index)}
+        >
+          <div className="flex flex-col items-end gap-0.5">
+            <span className="text-xs text-gray-500 text-right">
+              {index + 1}
+            </span>
+            {(hasAnimations || hasSkipped) && (
+              <ImagePlay
+                className="text-blue-500 w-3 h-3"
+                aria-label="GIFアニメーション情報あり"
+                role="img"
+              />
+            )}
+            {hasSkipped && (
+              <TriangleAlert
+                className="text-yellow-500 w-3 h-3"
+                aria-label="一部のアニメーションがスキップされました"
+                role="img"
+              />
+            )}
+          </div>
+          <Preview
+            canvas={file.canvas}
+            className={`w-full border-2 rounded overflow-hidden ${
+              isSelected
+                ? "border-blue-500"
+                : "border-transparent hover:border-gray-300"
+            }`}
+          />
         </div>
-        <Preview
-          canvas={file.canvas}
-          className={`w-full border-2 rounded overflow-hidden ${
-            isSelected
-              ? "border-blue-500"
-              : "border-transparent hover:border-gray-300"
-          }`}
-        />
-      </div>
-    </Dropdown>
-  );
-};
+      </Dropdown>
+    );
+  },
+);
+
+SlideItem.displayName = "SlideItem";
 
 export const SlideSidePanel: FC<SlideSidePanelProps> = ({
   files,

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -45,9 +45,7 @@ const SlideItem: FC<SlideItemProps> = memo(
     const hasAnimations = (file.animations?.length ?? 0) > 0;
     const hasSkippedAnimations = (file.skippedAnimations?.length ?? 0) > 0;
 
-    const imagePlayLabel = hasAnimations
-      ? "GIFアニメーションを含む"
-      : "元のGIFにアニメーションが含まれていたが、スキップされました";
+    const imagePlayLabel = "GIFアニメーションを含む";
 
     const menuItems: MenuProps["items"] = useMemo(
       () => [


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual indicators showing which slides contain GIF animations
  * Added warning labels for slides with skipped animations

* **UI Improvements**
  * Play icons now displayed on animated slide previews
  * Warning icons appear for slides with skipped animations
  * Enhanced slide index and status accessibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wraps `SlideItem` in `React.memo` and adds status icons (`ImagePlay`, `TriangleAlert`) to the pick-slide list to indicate slides containing GIF animations or slides where animations were skipped. A well-structured `sr-only` span provides full screen-reader context for each slide's state, and all decorative icons are correctly marked `aria-hidden="true"`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic errors, data issues, or security concerns.

Changes are well-scoped: a memo wrap with a proper displayName, two small icon additions with correct conditional logic, and a thorough accessible label. No P0 or P1 findings.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx | Wraps SlideItem in React.memo, adds displayName, and renders ImagePlay/TriangleAlert icons with a complete sr-only accessible label for GIF and skipped-animation states. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SlideItem render] --> B{hasAnimations?}
    A --> C{hasSkippedAnimations?}
    B -->|true| D[Show ImagePlay icon]
    C -->|true| D
    C -->|true| E[Show TriangleAlert icon]
    B -->|true| F[SR: GIFアニメーションを含む]
    C -->|true| G[SR: 一部のアニメーションがスキップされました]
    D --> H[aria-hidden=true]
    E --> H
    F --> I[sr-only span]
    G --> I
```

<sub>Reviews (2): Last reviewed commit: ["fix: remove aria-hidden from Preview, re..."](https://github.com/o-tr/imageslide-converter/commit/9b1136ddeaf7a25cf85b46391fde3eb85aa4c4f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30589270)</sub>

<!-- /greptile_comment -->