### PR TITLE
feat: 透過GIF同士の重なり検出と警告表示を追加

### DIFF
--- a/src/_types/file-picker.ts
+++ b/src/_types/file-picker.ts
@@ -10,7 +10,9 @@ export type SelectedFileAnimation = {
   frames: OffscreenCanvas[];
 };
 
-export type SkippedAnimation = PixelRect;
+export type SkippedAnimation = PixelRect & {
+  reason: "static-overlap" | "transparent-gif-overlap";
+};
 
 export type SelectedFile = {
   id: string;

--- a/src/app/(_convert)/convert/pick/_components/FileList/MainPreviewArea.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/MainPreviewArea.tsx
@@ -151,27 +151,49 @@ const SkippedAnimationsOverlay: FC<{ file: SelectedFile }> = ({ file }) => {
   if (!file.skippedAnimations?.length) return null;
   return (
     <>
-      {file.skippedAnimations.map((anim, i) => (
-        <div
-          key={`skipped-${i}-${anim.x}-${anim.y}-${anim.w}-${anim.h}`}
-          className="absolute group border-2 border-red-500 pointer-events-auto"
-          style={{
-            left: `${(anim.x / file.canvas.width) * 100}%`,
-            top: `${(anim.y / file.canvas.height) * 100}%`,
-            width: `${(anim.w / file.canvas.width) * 100}%`,
-            height: `${(anim.h / file.canvas.height) * 100}%`,
-          }}
-        >
-          <div className="absolute inset-0 bg-red-500/0 group-hover:bg-red-500/20 transition-colors duration-150" />
-          <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none">
-            <span className="text-[10px] leading-tight text-red-700 bg-white/90 px-1.5 py-0.5 rounded shadow text-center">
-              アニメーションが無効化されました
-              <br />
-              （重なっています）
-            </span>
+      {file.skippedAnimations.map((anim, i) => {
+        const isTransparentGifOverlap =
+          anim.reason === "transparent-gif-overlap";
+        return (
+          <div
+            key={`skipped-${i}-${anim.x}-${anim.y}-${anim.w}-${anim.h}`}
+            className={`absolute group border-2 pointer-events-auto ${
+              isTransparentGifOverlap ? "border-yellow-500" : "border-red-500"
+            }`}
+            style={{
+              left: `${(anim.x / file.canvas.width) * 100}%`,
+              top: `${(anim.y / file.canvas.height) * 100}%`,
+              width: `${(anim.w / file.canvas.width) * 100}%`,
+              height: `${(anim.h / file.canvas.height) * 100}%`,
+            }}
+          >
+            <div
+              className={`absolute inset-0 transition-colors duration-150 ${
+                isTransparentGifOverlap
+                  ? "bg-yellow-500/0 group-hover:bg-yellow-500/20"
+                  : "bg-red-500/0 group-hover:bg-red-500/20"
+              }`}
+            />
+            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none">
+              <span
+                className={`text-[10px] leading-tight bg-white/90 px-1.5 py-0.5 rounded shadow text-center ${
+                  isTransparentGifOverlap ? "text-yellow-700" : "text-red-700"
+                }`}
+              >
+                {isTransparentGifOverlap ? (
+                  <>透過GIF同士が重なっています</>
+                ) : (
+                  <>
+                    アニメーションが無効化されました
+                    <br />
+                    （重なっています）
+                  </>
+                )}
+              </span>
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </>
   );
 };

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -44,11 +44,21 @@ const SlideItem: FC<SlideItemProps> = memo(
 
     const hasAnimations = (file.animations?.length ?? 0) > 0;
     const hasSkippedAnimations = (file.skippedAnimations?.length ?? 0) > 0;
+    const hasHardSkips = file.skippedAnimations?.some(
+      (a) => a.reason === "static-overlap",
+    );
+    const hasTransparentGifOverlap = file.skippedAnimations?.some(
+      (a) => a.reason === "transparent-gif-overlap",
+    );
 
     const slideStatusParts: string[] = [];
     if (hasAnimations) slideStatusParts.push("GIFアニメーションを含む");
-    if (hasSkippedAnimations)
-      slideStatusParts.push("一部のアニメーションに警告があります");
+    if (hasSkippedAnimations) {
+      if (hasHardSkips)
+        slideStatusParts.push("一部のアニメーションがスキップされました");
+      if (hasTransparentGifOverlap)
+        slideStatusParts.push("一部のアニメーションに警告があります");
+    }
     const slideStatus = slideStatusParts.join("、");
 
     const menuItems: MenuProps["items"] = [
@@ -83,12 +93,12 @@ const SlideItem: FC<SlideItemProps> = memo(
             >
               {index + 1}
             </span>
-            {(hasAnimations || hasSkippedAnimations) && (
+            {hasAnimations && (
               <ImagePlay className="text-blue-500 w-3 h-3" aria-hidden="true" />
             )}
             {hasSkippedAnimations && (
               <TriangleAlert
-                className="text-yellow-500 w-3 h-3"
+                className={`w-3 h-3 ${hasHardSkips ? "text-red-500" : "text-yellow-500"}`}
                 aria-hidden="true"
               />
             )}

--- a/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
+++ b/src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx
@@ -48,7 +48,7 @@ const SlideItem: FC<SlideItemProps> = memo(
     const slideStatusParts: string[] = [];
     if (hasAnimations) slideStatusParts.push("GIFアニメーションを含む");
     if (hasSkippedAnimations)
-      slideStatusParts.push("一部のアニメーションがスキップされました");
+      slideStatusParts.push("一部のアニメーションに警告があります");
     const slideStatus = slideStatusParts.join("、");
 
     const menuItems: MenuProps["items"] = [

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -1,4 +1,4 @@
-import type { SelectedFileAnimation } from "@/_types/file-picker";
+import type { SelectedFileAnimation, SkippedAnimation } from "@/_types/file-picker";
 import type { SlidePageElement } from "@/_types/google-slides-api";
 import type { AnimatedGifCandidate } from "@/_types/lib/google/gifAnimation";
 import type {
@@ -310,9 +310,58 @@ const compositeWithBackground = (
   return composited;
 };
 
+const checkGifOverlapTransparency = (
+  upper: AnimatedGifCandidate,
+  intersectionRect: PixelRect,
+): boolean => {
+  const { rawFrames, gifWidth, gifHeight, pixelRect: upperPixelRect } = upper;
+  const sampleIndices = rawFrames.map((_, i) => i);
+  const { w: targetW, h: targetH } = clampDimensions(gifWidth, gifHeight);
+
+  const composedFrames = buildComposedFrames(
+    rawFrames,
+    sampleIndices,
+    gifWidth,
+    gifHeight,
+    targetW,
+    targetH,
+  );
+
+  // Slide-coordinate intersection → upper GIF composed-canvas coordinates
+  const scaleX = targetW / upperPixelRect.w;
+  const scaleY = targetH / upperPixelRect.h;
+  const localX = Math.floor((intersectionRect.x - upperPixelRect.x) * scaleX);
+  const localY = Math.floor((intersectionRect.y - upperPixelRect.y) * scaleY);
+  const localW = Math.max(1, Math.ceil(intersectionRect.w * scaleX));
+  const localH = Math.max(1, Math.ceil(intersectionRect.h * scaleY));
+
+  const clampedX = Math.max(0, localX);
+  const clampedY = Math.max(0, localY);
+  const clampedW = Math.min(localW, targetW - clampedX);
+  const clampedH = Math.min(localH, targetH - clampedY);
+
+  if (clampedW <= 0 || clampedH <= 0) return false;
+
+  for (const frame of composedFrames) {
+    const ctx = frame.getContext("2d");
+    if (!ctx) continue;
+    const imageData = ctx.getImageData(
+      clampedX,
+      clampedY,
+      clampedW,
+      clampedH,
+    );
+    const data = imageData.data;
+    for (let p = 3; p < data.length; p += 4) {
+      if (data[p] === 0) return true;
+    }
+  }
+  return false;
+};
+
 export type ExtractGifAnimationsResult = {
   animations: SelectedFileAnimation[];
-  skipped: PixelRect[];
+  skipped: SkippedAnimation[];
 };
 
 export const extractGifAnimations = async (
@@ -564,14 +613,66 @@ export const extractGifAnimations = async (
     );
   }
 
-  const skippedRects: PixelRect[] = [];
+  const skippedRects: SkippedAnimation[] = [];
   for (const index of blockedByStaticIndices) {
-    skippedRects.push(animatedGifCandidates[index].pixelRect);
+    skippedRects.push({
+      ...animatedGifCandidates[index].pixelRect,
+      reason: "static-overlap",
+    });
   }
 
   const nonIntersectingAnimatedCandidates = animatedGifCandidates.filter(
     (_, index) => !blockedByStaticIndices.has(index),
   );
+
+  // Check for transparent-pixel overlaps between surviving animated GIFs.
+  // Upper GIFs (higher Z) that have transparent pixels over a lower GIF
+  // produce visual artifacts with RGB24 encoding, so we record a warning.
+  const survivingSorted = nonIntersectingAnimatedCandidates
+    .map((candidate) => ({
+      candidate,
+      z: elementZOrder.get(candidate.element) ?? 0,
+    }))
+    .sort((a, b) => b.z - a.z);
+
+  for (let i = 0; i < survivingSorted.length; i++) {
+    const upper = survivingSorted[i];
+    for (let j = i + 1; j < survivingSorted.length; j++) {
+      const lower = survivingSorted[j];
+      if (!rectsIntersect(upper.candidate.pixelRect, lower.candidate.pixelRect))
+        continue;
+
+      const ix =
+        Math.max(
+          upper.candidate.pixelRect.x,
+          lower.candidate.pixelRect.x,
+        );
+      const iy =
+        Math.max(
+          upper.candidate.pixelRect.y,
+          lower.candidate.pixelRect.y,
+        );
+      const iw =
+        Math.min(
+          upper.candidate.pixelRect.x + upper.candidate.pixelRect.w,
+          lower.candidate.pixelRect.x + lower.candidate.pixelRect.w,
+        ) - ix;
+      const ih =
+        Math.min(
+          upper.candidate.pixelRect.y + upper.candidate.pixelRect.h,
+          lower.candidate.pixelRect.y + lower.candidate.pixelRect.h,
+        ) - iy;
+      if (iw <= 0 || ih <= 0) continue;
+
+      const intersectionRect: PixelRect = { x: ix, y: iy, w: iw, h: ih };
+      if (checkGifOverlapTransparency(upper.candidate, intersectionRect)) {
+        skippedRects.push({
+          ...intersectionRect,
+          reason: "transparent-gif-overlap",
+        });
+      }
+    }
+  }
 
   const results = nonIntersectingAnimatedCandidates
     .map(

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -177,6 +177,7 @@ const buildComposedFrames = (
   gifHeight: number,
   targetW: number,
   targetH: number,
+  maxOutputFrames: number = MAX_FRAMES,
 ): OffscreenCanvas[] => {
   const compositionCanvas = new OffscreenCanvas(gifWidth, gifHeight);
   const compositionCtx = compositionCanvas.getContext("2d");
@@ -237,7 +238,8 @@ const buildComposedFrames = (
       );
     }
     const pixelCount = Math.min(srcData.length, dstData.length);
-    for (let p = 0; p < pixelCount; p += 4) {
+    const alignedPixelCount = pixelCount - (pixelCount % 4);
+    for (let p = 0; p < alignedPixelCount; p += 4) {
       const srcA = srcData[p + 3] / 255;
       if (srcA === 0) continue;
 
@@ -271,10 +273,10 @@ const buildComposedFrames = (
       resultCtx.drawImage(compositionCanvas, 0, 0, targetW, targetH);
       output.push(result);
       samplePtr++;
-      if (output.length >= MAX_FRAMES) break;
+      if (output.length >= maxOutputFrames) break;
     }
 
-    if (output.length >= MAX_FRAMES) break;
+    if (output.length >= maxOutputFrames) break;
   }
 
   return output;
@@ -313,19 +315,13 @@ const compositeWithBackground = (
 const checkGifOverlapTransparency = (
   upper: AnimatedGifCandidate,
   intersectionRect: PixelRect,
+  composedFrames: OffscreenCanvas[],
 ): boolean => {
-  const { rawFrames, gifWidth, gifHeight, pixelRect: upperPixelRect } = upper;
-  const sampleIndices = rawFrames.map((_, i) => i);
-  const { w: targetW, h: targetH } = clampDimensions(gifWidth, gifHeight);
-
-  const composedFrames = buildComposedFrames(
-    rawFrames,
-    sampleIndices,
-    gifWidth,
-    gifHeight,
-    targetW,
-    targetH,
-  );
+  const { pixelRect: upperPixelRect } = upper;
+  const firstFrame = composedFrames[0];
+  if (!firstFrame) return false;
+  const targetW = firstFrame.width;
+  const targetH = firstFrame.height;
 
   // Slide-coordinate intersection → upper GIF composed-canvas coordinates
   const scaleX = targetW / upperPixelRect.w;
@@ -353,6 +349,7 @@ const checkGifOverlapTransparency = (
     );
     const data = imageData.data;
     for (let p = 3; p < data.length; p += 4) {
+      // Alpha === 0 means the lower GIF would show through in RGB24 output.
       if (data[p] === 0) return true;
     }
   }
@@ -613,12 +610,13 @@ export const extractGifAnimations = async (
     );
   }
 
-  const skippedRects: SkippedAnimation[] = [];
+  const skippedRectsMap = new Map<string, SkippedAnimation>();
   for (const index of blockedByStaticIndices) {
-    skippedRects.push({
-      ...animatedGifCandidates[index].pixelRect,
-      reason: "static-overlap",
-    });
+    const rect = animatedGifCandidates[index].pixelRect;
+    skippedRectsMap.set(
+      `${rect.x},${rect.y},${rect.w},${rect.h},static-overlap`,
+      { ...rect, reason: "static-overlap" },
+    );
   }
 
   const nonIntersectingAnimatedCandidates = animatedGifCandidates.filter(
@@ -635,12 +633,39 @@ export const extractGifAnimations = async (
     }))
     .sort((a, b) => b.z - a.z);
 
+  // Cache composed frames lazily: only build them for an upper candidate
+  // when it actually intersects with at least one lower candidate.
+  const transparencyCache = new Map<
+    SlidePageElement,
+    OffscreenCanvas[]
+  >();
+
   for (let i = 0; i < survivingSorted.length; i++) {
     const upper = survivingSorted[i];
+    let upperFrames = transparencyCache.get(upper.candidate.element);
+
     for (let j = i + 1; j < survivingSorted.length; j++) {
       const lower = survivingSorted[j];
       if (!rectsIntersect(upper.candidate.pixelRect, lower.candidate.pixelRect))
         continue;
+
+      if (!upperFrames) {
+        const sampleIndices = upper.candidate.rawFrames.map((_, idx) => idx);
+        const { w: targetW, h: targetH } = clampDimensions(
+          upper.candidate.gifWidth,
+          upper.candidate.gifHeight,
+        );
+        upperFrames = buildComposedFrames(
+          upper.candidate.rawFrames,
+          sampleIndices,
+          upper.candidate.gifWidth,
+          upper.candidate.gifHeight,
+          targetW,
+          targetH,
+          upper.candidate.rawFrames.length,
+        );
+        transparencyCache.set(upper.candidate.element, upperFrames);
+      }
 
       const ix =
         Math.max(
@@ -665,11 +690,17 @@ export const extractGifAnimations = async (
       if (iw <= 0 || ih <= 0) continue;
 
       const intersectionRect: PixelRect = { x: ix, y: iy, w: iw, h: ih };
-      if (checkGifOverlapTransparency(upper.candidate, intersectionRect)) {
-        skippedRects.push({
-          ...intersectionRect,
-          reason: "transparent-gif-overlap",
-        });
+      if (
+        checkGifOverlapTransparency(
+          upper.candidate,
+          intersectionRect,
+          upperFrames,
+        )
+      ) {
+        skippedRectsMap.set(
+          `${intersectionRect.x},${intersectionRect.y},${intersectionRect.w},${intersectionRect.h},transparent-gif-overlap`,
+          { ...intersectionRect, reason: "transparent-gif-overlap" },
+        );
       }
     }
   }
@@ -677,6 +708,7 @@ export const extractGifAnimations = async (
   const results = nonIntersectingAnimatedCandidates
     .map(
       ({
+        element,
         pixelRect,
         rawFrames,
         gifWidth,
@@ -695,15 +727,29 @@ export const extractGifAnimations = async (
             MAX_STORED_FRAME_DIMENSION,
           );
 
-          // Build composed GIF frames with proper inter-frame compositing
-          const composedFrames = buildComposedFrames(
-            rawFrames,
-            sampleIndices,
-            gifWidth,
-            gifHeight,
-            targetW,
-            targetH,
-          );
+          // Reuse full composed frames from transparencyCache when available.
+          const cachedFrames = transparencyCache.get(element);
+          let composedFrames: OffscreenCanvas[];
+          if (cachedFrames) {
+            composedFrames = sampleIndices.map((idx) => {
+              const frame = cachedFrames[idx];
+              if (!frame) {
+                throw new Error(
+                  `Cached frame index out of bounds: ${idx} >= ${cachedFrames.length}`,
+                );
+              }
+              return frame;
+            });
+          } else {
+            composedFrames = buildComposedFrames(
+              rawFrames,
+              sampleIndices,
+              gifWidth,
+              gifHeight,
+              targetW,
+              targetH,
+            );
+          }
           // compositeWithBackground bakes the full slide background (including
           // the static first frame of every other GIF) into each animation frame.
           // At runtime, when a higher-Z GIF has transparent pixels in an overlap
@@ -739,5 +785,8 @@ export const extractGifAnimations = async (
     )
     .filter((r): r is SelectedFileAnimation => !!r);
 
-  return { animations: results, skipped: skippedRects };
+  return {
+    animations: results,
+    skipped: Array.from(skippedRectsMap.values()),
+  };
 };

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -177,7 +177,6 @@ const buildComposedFrames = (
   gifHeight: number,
   targetW: number,
   targetH: number,
-  maxOutputFrames: number = MAX_FRAMES,
 ): OffscreenCanvas[] => {
   const compositionCanvas = new OffscreenCanvas(gifWidth, gifHeight);
   const compositionCtx = compositionCanvas.getContext("2d");
@@ -273,10 +272,10 @@ const buildComposedFrames = (
       resultCtx.drawImage(compositionCanvas, 0, 0, targetW, targetH);
       output.push(result);
       samplePtr++;
-      if (output.length >= maxOutputFrames) break;
+      if (output.length >= MAX_FRAMES) break;
     }
 
-    if (output.length >= maxOutputFrames) break;
+    if (output.length >= MAX_FRAMES) break;
   }
 
   return output;
@@ -313,48 +312,58 @@ const compositeWithBackground = (
 };
 
 /**
- * Compose all raw frames of an upper GIF incrementally, checking the
- * intersection region for fully-transparent pixels after each composed frame.
- * Returns true as soon as one transparent pixel is found, avoiding the memory
- * cost of materialising every frame upfront.
+ * Compose all raw frames of an upper GIF incrementally and check the given
+ * intersection rectangles for fully-transparent pixels on sampled frames only.
+ * Returns an array of rects that contain at least one transparent pixel.
+ * Composing proceeds through every raw frame so disposal state stays correct,
+ * but the actual pixel check is skipped for non-sampled frames.
  */
-const hasTransparentPixelInOverlap = (
+const findTransparentOverlapRects = (
   upper: AnimatedGifCandidate,
-  intersectionRect: PixelRect,
-): boolean => {
+  intersectionRects: PixelRect[],
+  sampledFrameIndices: Set<number>,
+): PixelRect[] => {
   const {
     rawFrames,
     gifWidth,
     gifHeight,
     pixelRect: upperPixelRect,
   } = upper;
+
   // Slide-coordinate intersection → upper GIF logical-screen coordinates.
-  // We compose on the original gifWidth×gifHeight canvas (same as
-  // buildComposedFrames), so scale against the logical screen size, not the
-  // clamped target size.
   const scaleX = gifWidth / upperPixelRect.w;
   const scaleY = gifHeight / upperPixelRect.h;
-  const localX = Math.floor((intersectionRect.x - upperPixelRect.x) * scaleX);
-  const localY = Math.floor((intersectionRect.y - upperPixelRect.y) * scaleY);
-  const localW = Math.max(1, Math.ceil(intersectionRect.w * scaleX));
-  const localH = Math.max(1, Math.ceil(intersectionRect.h * scaleY));
 
-  const clampedX = Math.max(0, localX);
-  const clampedY = Math.max(0, localY);
-  const clampedW = Math.max(
-    0,
-    Math.min(localX + localW, gifWidth) - clampedX,
-  );
-  const clampedH = Math.max(
-    0,
-    Math.min(localY + localH, gifHeight) - clampedY,
-  );
+  const regions = intersectionRects
+    .map((rect) => {
+      const localX = Math.floor((rect.x - upperPixelRect.x) * scaleX);
+      const localY = Math.floor((rect.y - upperPixelRect.y) * scaleY);
+      const localW = Math.max(1, Math.ceil(rect.w * scaleX));
+      const localH = Math.max(1, Math.ceil(rect.h * scaleY));
 
-  if (clampedW <= 0 || clampedH <= 0) return false;
+      const clampedX = Math.max(0, localX);
+      const clampedY = Math.max(0, localY);
+      const clampedW = Math.max(
+        0,
+        Math.min(localX + localW, gifWidth) - clampedX,
+      );
+      const clampedH = Math.max(
+        0,
+        Math.min(localY + localH, gifHeight) - clampedY,
+      );
+
+      return { rect, clampedX, clampedY, clampedW, clampedH };
+    })
+    .filter((r) => r.clampedW > 0 && r.clampedH > 0);
+
+  if (regions.length === 0) return [];
 
   const compositionCanvas = new OffscreenCanvas(gifWidth, gifHeight);
   const compositionCtx = compositionCanvas.getContext("2d");
   if (!compositionCtx) throw new Error("Cannot get 2d context");
+
+  const foundRects: PixelRect[] = [];
+  const foundSet = new Set<number>();
 
   let prevDisposal = 0;
   let prevDims: ParsedFrame["dims"] | null = null;
@@ -425,20 +434,32 @@ const hasTransparentPixelInOverlap = (
     prevDisposal = disposal;
     prevDims = frame.dims;
 
-    // Check the intersection region on this composed frame
-    const regionData = compositionCtx.getImageData(
-      clampedX,
-      clampedY,
-      clampedW,
-      clampedH,
-    );
-    const data = regionData.data;
-    for (let p = 3; p < data.length; p += 4) {
-      if (data[p] === 0) return true;
+    // Only check pixels on frames that end up in the sampled animation output.
+    if (!sampledFrameIndices.has(i)) continue;
+
+    for (let rIdx = 0; rIdx < regions.length; rIdx++) {
+      if (foundSet.has(rIdx)) continue;
+      const { rect, clampedX, clampedY, clampedW, clampedH } = regions[rIdx];
+      const regionData = compositionCtx.getImageData(
+        clampedX,
+        clampedY,
+        clampedW,
+        clampedH,
+      );
+      const data = regionData.data;
+      for (let p = 3; p < data.length; p += 4) {
+        if (data[p] === 0) {
+          foundSet.add(rIdx);
+          foundRects.push(rect);
+          break;
+        }
+      }
     }
+
+    if (foundSet.size === regions.length) break;
   }
 
-  return false;
+  return foundRects;
 };
 
 export type ExtractGifAnimationsResult = {
@@ -721,6 +742,9 @@ export const extractGifAnimations = async (
   for (let i = 0; i < survivingSorted.length; i++) {
     const upper = survivingSorted[i];
 
+    // Collect all intersection rectangles for this upper candidate first,
+    // then perform the expensive composition once and check every rect.
+    const overlapRects: PixelRect[] = [];
     for (let j = i + 1; j < survivingSorted.length; j++) {
       const lower = survivingSorted[j];
       if (!rectsIntersect(upper.candidate.pixelRect, lower.candidate.pixelRect))
@@ -748,13 +772,27 @@ export const extractGifAnimations = async (
         ) - iy;
       if (iw <= 0 || ih <= 0) continue;
 
-      const intersectionRect: PixelRect = { x: ix, y: iy, w: iw, h: ih };
-      if (hasTransparentPixelInOverlap(upper.candidate, intersectionRect)) {
-        skippedRectsMap.set(
-          `${intersectionRect.x},${intersectionRect.y},${intersectionRect.w},${intersectionRect.h},transparent-gif-overlap`,
-          { ...intersectionRect, reason: "transparent-gif-overlap" },
-        );
-      }
+      overlapRects.push({ x: ix, y: iy, w: iw, h: ih });
+    }
+
+    if (overlapRects.length === 0) continue;
+
+    const previewFps = derivePreviewFps(upper.candidate.rawFrames);
+    const sampledIndices = sampleFrameIndices(
+      upper.candidate.rawFrames,
+      previewFps,
+    );
+    const sampledFrameSet = new Set(sampledIndices);
+    const transparentRects = findTransparentOverlapRects(
+      upper.candidate,
+      overlapRects,
+      sampledFrameSet,
+    );
+    for (const rect of transparentRects) {
+      skippedRectsMap.set(
+        `${rect.x},${rect.y},${rect.w},${rect.h},transparent-gif-overlap`,
+        { ...rect, reason: "transparent-gif-overlap" },
+      );
     }
   }
 

--- a/src/lib/google/extractGifAnimations.ts
+++ b/src/lib/google/extractGifAnimations.ts
@@ -312,20 +312,28 @@ const compositeWithBackground = (
   return composited;
 };
 
-const checkGifOverlapTransparency = (
+/**
+ * Compose all raw frames of an upper GIF incrementally, checking the
+ * intersection region for fully-transparent pixels after each composed frame.
+ * Returns true as soon as one transparent pixel is found, avoiding the memory
+ * cost of materialising every frame upfront.
+ */
+const hasTransparentPixelInOverlap = (
   upper: AnimatedGifCandidate,
   intersectionRect: PixelRect,
-  composedFrames: OffscreenCanvas[],
 ): boolean => {
-  const { pixelRect: upperPixelRect } = upper;
-  const firstFrame = composedFrames[0];
-  if (!firstFrame) return false;
-  const targetW = firstFrame.width;
-  const targetH = firstFrame.height;
-
-  // Slide-coordinate intersection → upper GIF composed-canvas coordinates
-  const scaleX = targetW / upperPixelRect.w;
-  const scaleY = targetH / upperPixelRect.h;
+  const {
+    rawFrames,
+    gifWidth,
+    gifHeight,
+    pixelRect: upperPixelRect,
+  } = upper;
+  // Slide-coordinate intersection → upper GIF logical-screen coordinates.
+  // We compose on the original gifWidth×gifHeight canvas (same as
+  // buildComposedFrames), so scale against the logical screen size, not the
+  // clamped target size.
+  const scaleX = gifWidth / upperPixelRect.w;
+  const scaleY = gifHeight / upperPixelRect.h;
   const localX = Math.floor((intersectionRect.x - upperPixelRect.x) * scaleX);
   const localY = Math.floor((intersectionRect.y - upperPixelRect.y) * scaleY);
   const localW = Math.max(1, Math.ceil(intersectionRect.w * scaleX));
@@ -333,26 +341,103 @@ const checkGifOverlapTransparency = (
 
   const clampedX = Math.max(0, localX);
   const clampedY = Math.max(0, localY);
-  const clampedW = Math.min(localW, targetW - clampedX);
-  const clampedH = Math.min(localH, targetH - clampedY);
+  const clampedW = Math.max(
+    0,
+    Math.min(localX + localW, gifWidth) - clampedX,
+  );
+  const clampedH = Math.max(
+    0,
+    Math.min(localY + localH, gifHeight) - clampedY,
+  );
 
   if (clampedW <= 0 || clampedH <= 0) return false;
 
-  for (const frame of composedFrames) {
-    const ctx = frame.getContext("2d");
-    if (!ctx) continue;
-    const imageData = ctx.getImageData(
+  const compositionCanvas = new OffscreenCanvas(gifWidth, gifHeight);
+  const compositionCtx = compositionCanvas.getContext("2d");
+  if (!compositionCtx) throw new Error("Cannot get 2d context");
+
+  let prevDisposal = 0;
+  let prevDims: ParsedFrame["dims"] | null = null;
+  let prevSnapshot: ImageData | null = null;
+
+  for (let i = 0; i < rawFrames.length; i++) {
+    const frame = rawFrames[i];
+    const disposal = frame.disposalType ?? 0;
+
+    if (prevDims) {
+      if (prevDisposal === 2) {
+        compositionCtx.clearRect(
+          prevDims.left,
+          prevDims.top,
+          prevDims.width,
+          prevDims.height,
+        );
+      } else if (prevDisposal === 3 && prevSnapshot) {
+        compositionCtx.putImageData(prevSnapshot, prevDims.left, prevDims.top);
+        prevSnapshot = null;
+      }
+    }
+
+    if (disposal === 3) {
+      prevSnapshot = compositionCtx.getImageData(
+        frame.dims.left,
+        frame.dims.top,
+        frame.dims.width,
+        frame.dims.height,
+      );
+    }
+
+    const imageData = compositionCtx.getImageData(
+      frame.dims.left,
+      frame.dims.top,
+      frame.dims.width,
+      frame.dims.height,
+    );
+    const dstData = imageData.data;
+    const srcData = frame.patch;
+    const expectedLength = frame.dims.width * frame.dims.height * 4;
+    if (srcData.length < expectedLength) {
+      console.warn(
+        `GIF frame patch is smaller than expected: got ${srcData.length} bytes, expected ${expectedLength} (${frame.dims.width}×${frame.dims.height})`,
+      );
+    }
+    const pixelCount = Math.min(srcData.length, dstData.length);
+    const alignedPixelCount = pixelCount - (pixelCount % 4);
+    for (let p = 0; p < alignedPixelCount; p += 4) {
+      const srcA = srcData[p + 3] / 255;
+      if (srcA === 0) continue;
+      const dstA = dstData[p + 3] / 255;
+      const outA = srcA + dstA * (1 - srcA);
+      if (outA === 0) continue;
+      dstData[p] = Math.round(
+        (srcData[p] * srcA + dstData[p] * dstA * (1 - srcA)) / outA,
+      );
+      dstData[p + 1] = Math.round(
+        (srcData[p + 1] * srcA + dstData[p + 1] * dstA * (1 - srcA)) / outA,
+      );
+      dstData[p + 2] = Math.round(
+        (srcData[p + 2] * srcA + dstData[p + 2] * dstA * (1 - srcA)) / outA,
+      );
+      dstData[p + 3] = Math.round(outA * 255);
+    }
+    compositionCtx.putImageData(imageData, frame.dims.left, frame.dims.top);
+
+    prevDisposal = disposal;
+    prevDims = frame.dims;
+
+    // Check the intersection region on this composed frame
+    const regionData = compositionCtx.getImageData(
       clampedX,
       clampedY,
       clampedW,
       clampedH,
     );
-    const data = imageData.data;
+    const data = regionData.data;
     for (let p = 3; p < data.length; p += 4) {
-      // Alpha === 0 means the lower GIF would show through in RGB24 output.
       if (data[p] === 0) return true;
     }
   }
+
   return false;
 };
 
@@ -633,39 +718,13 @@ export const extractGifAnimations = async (
     }))
     .sort((a, b) => b.z - a.z);
 
-  // Cache composed frames lazily: only build them for an upper candidate
-  // when it actually intersects with at least one lower candidate.
-  const transparencyCache = new Map<
-    SlidePageElement,
-    OffscreenCanvas[]
-  >();
-
   for (let i = 0; i < survivingSorted.length; i++) {
     const upper = survivingSorted[i];
-    let upperFrames = transparencyCache.get(upper.candidate.element);
 
     for (let j = i + 1; j < survivingSorted.length; j++) {
       const lower = survivingSorted[j];
       if (!rectsIntersect(upper.candidate.pixelRect, lower.candidate.pixelRect))
         continue;
-
-      if (!upperFrames) {
-        const sampleIndices = upper.candidate.rawFrames.map((_, idx) => idx);
-        const { w: targetW, h: targetH } = clampDimensions(
-          upper.candidate.gifWidth,
-          upper.candidate.gifHeight,
-        );
-        upperFrames = buildComposedFrames(
-          upper.candidate.rawFrames,
-          sampleIndices,
-          upper.candidate.gifWidth,
-          upper.candidate.gifHeight,
-          targetW,
-          targetH,
-          upper.candidate.rawFrames.length,
-        );
-        transparencyCache.set(upper.candidate.element, upperFrames);
-      }
 
       const ix =
         Math.max(
@@ -690,13 +749,7 @@ export const extractGifAnimations = async (
       if (iw <= 0 || ih <= 0) continue;
 
       const intersectionRect: PixelRect = { x: ix, y: iy, w: iw, h: ih };
-      if (
-        checkGifOverlapTransparency(
-          upper.candidate,
-          intersectionRect,
-          upperFrames,
-        )
-      ) {
+      if (hasTransparentPixelInOverlap(upper.candidate, intersectionRect)) {
         skippedRectsMap.set(
           `${intersectionRect.x},${intersectionRect.y},${intersectionRect.w},${intersectionRect.h},transparent-gif-overlap`,
           { ...intersectionRect, reason: "transparent-gif-overlap" },
@@ -708,7 +761,6 @@ export const extractGifAnimations = async (
   const results = nonIntersectingAnimatedCandidates
     .map(
       ({
-        element,
         pixelRect,
         rawFrames,
         gifWidth,
@@ -727,29 +779,15 @@ export const extractGifAnimations = async (
             MAX_STORED_FRAME_DIMENSION,
           );
 
-          // Reuse full composed frames from transparencyCache when available.
-          const cachedFrames = transparencyCache.get(element);
-          let composedFrames: OffscreenCanvas[];
-          if (cachedFrames) {
-            composedFrames = sampleIndices.map((idx) => {
-              const frame = cachedFrames[idx];
-              if (!frame) {
-                throw new Error(
-                  `Cached frame index out of bounds: ${idx} >= ${cachedFrames.length}`,
-                );
-              }
-              return frame;
-            });
-          } else {
-            composedFrames = buildComposedFrames(
-              rawFrames,
-              sampleIndices,
-              gifWidth,
-              gifHeight,
-              targetW,
-              targetH,
-            );
-          }
+          // Build composed GIF frames with proper inter-frame compositing
+          const composedFrames = buildComposedFrames(
+            rawFrames,
+            sampleIndices,
+            gifWidth,
+            gifHeight,
+            targetW,
+            targetH,
+          );
           // compositeWithBackground bakes the full slide background (including
           // the static first frame of every other GIF) into each animation frame.
           // At runtime, when a higher-Z GIF has transparent pixels in an overlap


### PR DESCRIPTION
- SkippedAnimation に reason を追加 (static-overlap / transparent-gif-overlap)
- extractGifAnimations で surviving GIF 間の透明ピクセル重なりを検出
- MainPreviewArea で transparent-gif-overlap を黄色ボーダーで表示
- SlideSidePanel の警告文言を更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skipped animations now carry a reason tag and are detected as either static-overlap or transparent-GIF-overlap.
  * Added detection for transparent-pixel overlaps between animated GIFs.

* **UI Updates**
  * Skipped-animation visuals and alert colors now reflect the specific reason (red for static overlap, yellow for transparent-GIF overlap).
  * Slide status messages distinguish hard skips from warnings for clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds detection and UI feedback for transparent-pixel overlaps between surviving animated GIFs, in addition to the existing static-element overlap detection. `SkippedAnimation` gains a `reason` discriminant, `findTransparentOverlapRects` performs a full disposal-aware per-frame composition to detect alpha=0 pixels in sampled frames, and the UI surfaces yellow warnings (vs. red hard-skips) for these cases.

The implementation is solid: the new composition loop correctly handles all four GIF disposal methods (do-not-dispose, leave-in-place, clear-to-background, restore-to-previous) and iterates all raw frames for correct disposal state while only doing pixel inspection on sampled frame indices, neatly side-stepping the MAX_FRAMES=60 truncation issue that affected `buildComposedFrames`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic errors or regressions found; the new transparency-detection path is well-isolated from existing animation output.

All changed files are additive or narrowly scoped UI changes. The core new function findTransparentOverlapRects correctly implements GIF disposal methods (0/1/2/3), iterates every raw frame for accurate state tracking, and only pays the pixel-inspection cost on sampled frames spread across the full animation. No P1/P0 issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/google/extractGifAnimations.ts | Adds findTransparentOverlapRects (disposal-aware GIF composition + transparency scan) and integrates transparent-gif-overlap detection into the main extraction flow; also defensively aligns the pixel loop in buildComposedFrames to multiples of 4. |
| src/_types/file-picker.ts | Extends SkippedAnimation with a reason discriminant (static-overlap | transparent-gif-overlap), cleanly typed as an intersection with PixelRect. |
| src/app/(_convert)/convert/pick/_components/FileList/MainPreviewArea.tsx | Renders yellow border/hover overlay for transparent-gif-overlap vs. existing red for static-overlap; tooltip text updated accordingly. |
| src/app/(_convert)/convert/pick/_components/FileList/SlideSidePanel.tsx | Distinguishes hard-skip (red icon + スキップされました) from transparent-gif-overlap (yellow icon + 警告があります) in slide status; ImagePlay icon now only shown when surviving animations exist. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[extractGifAnimations] --> B[Detect static-element overlaps]
    B --> C{blockedByStaticIndices}
    C -->|blocked| D[skippedRectsMap\nreason: static-overlap]
    C -->|surviving| E[nonIntersectingAnimatedCandidates]
    E --> F[Sort surviving GIFs by Z-order desc]
    F --> G{For each upper GIF\ncheck lower GIFs}
    G -->|intersects lower GIF| H[Compute intersection rect]
    H --> I[sampleFrameIndices\nfull animation range]
    I --> J[findTransparentOverlapRects\ndisposal-aware composition]
    J --> K{transparent pixel\nin intersection?}
    K -->|yes| L[skippedRectsMap\nreason: transparent-gif-overlap]
    K -->|no| M[no warning]
    G -->|no intersection| M
    D --> N[ExtractGifAnimationsResult\nskipped: SkippedAnimation array]
    L --> N
    E --> O[buildComposedFrames - animations]
    O --> N
    N --> P{UI rendering}
    P -->|static-overlap| Q[Red border overlay\nTriangleAlert red]
    P -->|transparent-gif-overlap| R[Yellow border overlay\nTriangleAlert yellow]
```

<sub>Reviews (4): Last reviewed commit: ["fix: レビュー指摘対応 - サンプリングフレームのみをチェックし冗長パラメー..."](https://github.com/o-tr/imageslide-converter/commit/a1bade533e281a8aea9add47b27b7a1f9f7b53e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30599215)</sub>

<!-- /greptile_comment -->